### PR TITLE
Back Ticks Break Some Databases (for example PostgreSQL)

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -135,9 +135,7 @@ module Brainstem
       per_page = calculate_per_page(options)
       page = calculate_page(options)
 
-      table_name = scope.connection.quote_table_name(options[:table_name])
-
-      [scope.limit(per_page).offset(per_page * (page - 1)).uniq, scope.select("distinct #{table_name}.id").count] # as of Rails 3.2.5, uniq.count generates the wrong SQL.
+      [scope.limit(per_page).offset(per_page * (page - 1)).uniq, scope.select("distinct #{scope.connection.quote_table_name(options[:table_name])}.id").count] # as of Rails 3.2.5, uniq.count generates the wrong SQL.
     end
 
     def calculate_per_page(options)


### PR DESCRIPTION
Added in `quote_table_name` to the counters (the existing code didn't work with Postgres).
