### PR TITLE
ActiveRecord::Associations::Preloader changed signature in ActiveRecord 4.1

### DIFF
--- a/brainstem.gemspec
+++ b/brainstem.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Brainstem::VERSION
 
-  gem.add_dependency "activerecord", ">= 3.0"
+  gem.add_dependency "activerecord", ">= 3.2"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "redcarpet" # for markdown in yard

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -330,7 +330,7 @@ module Brainstem
           association_names_to_preload.reject! { |association| !reflections.has_key?(association) }
         end
         if association_names_to_preload.any?
-          ActiveRecord::Associations::Preloader.new(models, association_names_to_preload).run
+          preload(models, association_names_to_preload)
           Brainstem.logger.info "Eager loaded #{association_names_to_preload.join(", ")}."
         end
       end
@@ -369,6 +369,14 @@ module Brainstem
     def rewrite_keys_as_objects!(struct)
       (struct.keys - [:count, :results]).each do |key|
         struct[key] = struct[key].inject({}) {|memo, obj| memo[obj[:id] || obj["id"] || "unknown_id"] = obj; memo }
+      end
+    end
+
+    def preload(models, association_names)
+      if Gem.loaded_specs['activerecord'].version >= Gem::Version.create('4.1')
+        ActiveRecord::Associations::Preloader.new.preload(models, association_names)
+      else
+        ActiveRecord::Associations::Preloader.new(models, association_names).run
       end
     end
   end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -259,7 +259,7 @@ describe Brainstem::PresenterCollection do
 
       it "preloads associations when they are full model-level associations" do
         # Here, primary_maven is a method on Workspace, not a true association.
-        mock(ActiveRecord::Associations::Preloader).new(anything, [:tasks]) { mock!.run }
+        mock(@presenter_collection).preload(anything, [:tasks])
         result = @presenter_collection.presenting("workspaces", :params => { :include => "tasks" }) { Workspace.order('id desc') }
         result[:tasks].length.should > 0
       end


### PR DESCRIPTION
Add a conditional depending on the version of ActiveRecord being used.
