### PR TITLE
add back in skipping of default filters to ControllerMethods.present_objects

### DIFF
--- a/lib/brainstem/controller_methods.rb
+++ b/lib/brainstem/controller_methods.rb
@@ -27,7 +27,7 @@ module Brainstem
     #                           only required if the name cannot be inferred.
     # @return (see PresenterCollection#presenting)
     def present_object(objects, options = {})
-      options.merge!(:params => params)
+      options.merge!(:params => params, :apply_default_filters => false)
 
       if objects.is_a?(ActiveRecord::Relation) || objects.is_a?(Array)
         raise ActiveRecord::RecordNotFound if objects.empty?

--- a/spec/brainstem/controller_methods_spec.rb
+++ b/spec/brainstem/controller_methods_spec.rb
@@ -76,6 +76,11 @@ describe Brainstem::ControllerMethods do
         @controller.present_object(Workspace.all)
         @controller.call_results[:options][:params][:only].should be_nil
       end
+
+      it "passes :apply_default_filters => false to the PresenterCollection so that filters are not applied by default" do
+        @controller.present_object(Workspace.find(1))
+        @controller.call_results[:options][:apply_default_filters].should == false
+      end
     end
   end
 end


### PR DESCRIPTION
We recommend using #present_object in your API controllers when handling
show, update, and create requests where you wouldn't want to return an
empty set because of default filters.'
