### PR TITLE
Convert specs to RSpec 3.0.2 syntax with Transpec

### DIFF
--- a/spec/brainstem/controller_methods_spec.rb
+++ b/spec/brainstem/controller_methods_spec.rb
@@ -33,53 +33,53 @@ describe Brainstem::ControllerMethods do
 
       it "works with arrays of ActiveRecord objects" do
         @controller.present_object([Workspace.find(1), Workspace.find(3)])
-        @controller.call_results[:klass].should == Workspace
-        @controller.call_results[:options][:as].should == "workspaces"
-        @controller.call_results[:block_result].pluck(:id).should == [1, 3]
+        expect(@controller.call_results[:klass]).to eq(Workspace)
+        expect(@controller.call_results[:options][:as]).to eq("workspaces")
+        expect(@controller.call_results[:block_result].pluck(:id)).to eq([1, 3])
       end
 
       it "works with a Relation" do
         @controller.present_object(Workspace.owned_by(1))
-        @controller.call_results[:klass].should == Workspace
-        @controller.call_results[:options][:as].should == "workspaces"
-        @controller.call_results[:block_result].pluck(:id).should == [1, 2, 3, 4]
+        expect(@controller.call_results[:klass]).to eq(Workspace)
+        expect(@controller.call_results[:options][:as]).to eq("workspaces")
+        expect(@controller.call_results[:block_result].pluck(:id)).to eq([1, 2, 3, 4])
       end
 
       it "works with singleton objects" do
         @controller.present_object(Workspace.find(1))
-        @controller.call_results[:klass].should == Workspace
-        @controller.call_results[:options][:as].should == "workspaces"
-        @controller.call_results[:block_result].pluck(:id).should == [1]
+        expect(@controller.call_results[:klass]).to eq(Workspace)
+        expect(@controller.call_results[:options][:as]).to eq("workspaces")
+        expect(@controller.call_results[:block_result].pluck(:id)).to eq([1])
       end
 
       it "accepts a key map" do
         @controller.present_object(Workspace.find(1), :key_map => { "Workspace" => "your_workspaces" })
-        @controller.call_results[:klass].should == Workspace
-        @controller.call_results[:options][:as].should == "your_workspaces"
-        @controller.call_results[:block_result].pluck(:id).should == [1]
+        expect(@controller.call_results[:klass]).to eq(Workspace)
+        expect(@controller.call_results[:options][:as]).to eq("your_workspaces")
+        expect(@controller.call_results[:block_result].pluck(:id)).to eq([1])
       end
 
       it "passes through the controller params" do
         @controller.present_object(Workspace.find(1), :key_map => { "Workspace" => "your_workspaces" })
-        @controller.call_results[:options][:params].should == @controller.params.merge(:only => '1')
+        expect(@controller.call_results[:options][:params]).to eq(@controller.params.merge(:only => '1'))
       end
 
       it "passes through supplied options" do
         @controller.present_object(Workspace.find(1), :foo => :bar)
-        @controller.call_results[:options][:foo].should == :bar
+        expect(@controller.call_results[:options][:foo]).to eq(:bar)
       end
 
       it "adds an only param if there is only one object to present" do
         @controller.present_object(Workspace.find(1))
-        @controller.call_results[:options][:params][:only].should == "1"
+        expect(@controller.call_results[:options][:params][:only]).to eq("1")
 
         @controller.present_object(Workspace.all)
-        @controller.call_results[:options][:params][:only].should be_nil
+        expect(@controller.call_results[:options][:params][:only]).to be_nil
       end
 
       it "passes :apply_default_filters => false to the PresenterCollection so that filters are not applied by default" do
         @controller.present_object(Workspace.find(1))
-        @controller.call_results[:options][:apply_default_filters].should == false
+        expect(@controller.call_results[:options][:apply_default_filters]).to eq(false)
       end
     end
   end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -22,81 +22,81 @@ describe Brainstem::PresenterCollection do
       end
 
       it "has a global per_page default" do
-        @presenter_collection.presenting("workspaces") { Workspace.order('id desc') }[:workspaces].length.should == 2
+        expect(@presenter_collection.presenting("workspaces") { Workspace.order('id desc') }[:workspaces].length).to eq(2)
       end
 
       it "will not accept a per_page less than 1" do
-        @presenter_collection.presenting("workspaces", :params => { :per_page => 0 }) { Workspace.order('id desc') }[:workspaces].length.should == 2
-        @presenter_collection.presenting("workspaces", :per_page => 0) { Workspace.order('id desc') }[:workspaces].length.should == 2
+        expect(@presenter_collection.presenting("workspaces", :params => { :per_page => 0 }) { Workspace.order('id desc') }[:workspaces].length).to eq(2)
+        expect(@presenter_collection.presenting("workspaces", :per_page => 0) { Workspace.order('id desc') }[:workspaces].length).to eq(2)
       end
 
       it "will accept strings" do
         struct = @presenter_collection.presenting("workspaces", :params => { :per_page => "1", :page => "2" }) { Workspace.order('id desc') }
-        struct[:results].first[:id].should == Workspace.order('id desc')[1].id.to_s
+        expect(struct[:results].first[:id]).to eq(Workspace.order('id desc')[1].id.to_s)
       end
 
       it "has a global max_per_page default" do
-        @presenter_collection.presenting("workspaces", :params => { :per_page => 5 }) { Workspace.order('id desc') }[:workspaces].length.should == 3
+        expect(@presenter_collection.presenting("workspaces", :params => { :per_page => 5 }) { Workspace.order('id desc') }[:workspaces].length).to eq(3)
       end
 
       it "takes a configurable default page size and max page size" do
-        @presenter_collection.presenting("workspaces", :params => { :per_page => 5 }, :max_per_page => 4) { Workspace.order('id desc') }[:workspaces].length.should == 4
+        expect(@presenter_collection.presenting("workspaces", :params => { :per_page => 5 }, :max_per_page => 4) { Workspace.order('id desc') }[:workspaces].length).to eq(4)
       end
 
       describe "limits and offsets" do
         context "when only per_page and page are present" do
           it "honors the user's requested page size and page and returns counts" do
             result = @presenter_collection.presenting("workspaces", :params => { :per_page => 1, :page => 2 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[1].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[1].id.to_s)
 
             result = @presenter_collection.presenting("workspaces", :params => { :per_page => 2, :page => 2 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 2
-            result.map { |m| m[:id] }.should == Workspace.order('id desc')[2..3].map(&:id).map(&:to_s)
+            expect(result.length).to eq(2)
+            expect(result.map { |m| m[:id] }).to eq(Workspace.order('id desc')[2..3].map(&:id).map(&:to_s))
           end
 
           it "defaults to 1 if the page number is less than 1" do
             result = @presenter_collection.presenting("workspaces", :params => { :per_page => 1, :page => 0 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[0].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[0].id.to_s)
           end
         end
 
         context "when only limit and offset are present" do
           it "honors the user's requested limit and offset and returns counts" do
             result = @presenter_collection.presenting("workspaces", :params => { :limit => 1, :offset => 2 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[2].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[2].id.to_s)
 
             result = @presenter_collection.presenting("workspaces", :params => { :limit => 2, :offset => 2 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 2
-            result.map { |m| m[:id] }.should == Workspace.order('id desc')[2..3].map(&:id).map(&:to_s)
+            expect(result.length).to eq(2)
+            expect(result.map { |m| m[:id] }).to eq(Workspace.order('id desc')[2..3].map(&:id).map(&:to_s))
           end
 
           it "defaults to offset 0 if the passed offset is less than 0 and limit to 1 if the passed limit is less than 1" do
             stub.proxy(@presenter_collection).calculate_offset(anything).times(1)
             stub.proxy(@presenter_collection).calculate_limit(anything).times(1)
             result = @presenter_collection.presenting("workspaces", :params => { :limit => -1, :offset => -1 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[0].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[0].id.to_s)
           end
         end
 
         context "when both sets of params are present" do
           it "prefers limit and offset over per_page and page" do
             result = @presenter_collection.presenting("workspaces", :params => { :limit => 1, :offset => 0, :per_page => 2, :page => 2 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[0].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[0].id.to_s)
           end
 
           it "uses per_page and page if limit and offset are not complete" do
             result = @presenter_collection.presenting("workspaces", :params => { :limit => 5, :per_page => 1, :page => 0 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[0].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[0].id.to_s)
 
             result = @presenter_collection.presenting("workspaces", :params => { :offset => 5, :per_page => 1, :page => 0 }) { Workspace.order('id desc') }[:results]
-            result.length.should == 1
-            result.first[:id].should == Workspace.order('id desc')[0].id.to_s
+            expect(result.length).to eq(1)
+            expect(result.first[:id]).to eq(Workspace.order('id desc')[0].id.to_s)
           end
         end
       end
@@ -107,34 +107,34 @@ describe Brainstem::PresenterCollection do
             it "should raise the provided error class when the empty_error_class option is provided" do
               class MyException < Exception; end
 
-              lambda {
+              expect {
                 @presenter_collection.presenting("workspaces", :raise_on_empty => true, :empty_error_class => MyException) { Workspace.where(:id => nil) }
-              }.should raise_error(MyException)
+              }.to raise_error(MyException)
             end
 
             it "should raise ActiveRecord::RecordNotFound when the empty_error_class option is not provided" do
-              lambda {
+              expect {
                 @presenter_collection.presenting("workspaces", :raise_on_empty => true) { Workspace.where(:id => nil) }
-              }.should raise_error(ActiveRecord::RecordNotFound)
+              }.to raise_error(ActiveRecord::RecordNotFound)
             end
           end
 
           context "results are not empty" do
             it "should not raise an exception" do
-              Workspace.count.should > 0
+              expect(Workspace.count).to be > 0
 
-              lambda {
+              expect {
                 @presenter_collection.presenting("workspaces", :raise_on_empty => true) { Workspace.order('id desc') }
-              }.should_not raise_error
+              }.not_to raise_error
             end
           end
         end
 
         context "raise_on_empty is false" do
           it "should not raise an exception when the results are empty" do
-            lambda { 
+            expect { 
               @presenter_collection.presenting("workspaces") { Workspace.where(:id => nil) }
-            }.should_not raise_error
+            }.not_to raise_error
           end
         end
       end
@@ -147,7 +147,7 @@ describe Brainstem::PresenterCollection do
 
         it "returns the unique count by model id" do
           result = @presenter_collection.presenting("workspaces", :params => { :per_page => 2, :page => 1 }) { Workspace.order('id desc') }
-          result[:count].should == Workspace.count
+          expect(result[:count]).to eq(Workspace.count)
         end
       end
     end
@@ -155,157 +155,157 @@ describe Brainstem::PresenterCollection do
     describe "uses presenters" do
       it "finds presenter by table name string" do
         result = @presenter_collection.presenting("workspaces") { Workspace.order('id desc') }
-        result[:workspaces].length.should eq(Workspace.count)
+        expect(result[:workspaces].length).to eq(Workspace.count)
       end
 
       it "finds presenter by model name string" do
         result = @presenter_collection.presenting("Workspace") { order('id desc') }
-        result[:workspaces].length.should eq(Workspace.count)
+        expect(result[:workspaces].length).to eq(Workspace.count)
       end
 
       it "finds presenter by model" do
         result = @presenter_collection.presenting(Workspace) { order('id desc') }
-        result[:workspaces].length.should eq(Workspace.count)
+        expect(result[:workspaces].length).to eq(Workspace.count)
       end
 
       it "infers the table name from the model" do
         result = @presenter_collection.presenting("not_workspaces", :model => "Workspace", :params => { :per_page => 2, :page => 1 }) { Workspace.order('id desc') }
-        result[:not_workspaces].should_not be_empty
-        result[:count].should == Workspace.count
+        expect(result[:not_workspaces]).not_to be_empty
+        expect(result[:count]).to eq(Workspace.count)
       end
     end
 
     describe "the 'results' top level key" do
       it "comes back with an explicit list of the matching results" do
         structure = @presenter_collection.presenting("workspaces", :params => { :include => "tasks" }, :max_per_page => 2) { Workspace.where(:id => 1) }
-        structure.keys.should =~ [:workspaces, :tasks, :count, :results]
-        structure[:results].should == Workspace.where(:id => 1).limit(2).map {|w| { :key => "workspaces", :id => w.id.to_s } }
-        structure[:workspaces].keys.should == %w[1]
+        expect(structure.keys).to match_array([:workspaces, :tasks, :count, :results])
+        expect(structure[:results]).to eq(Workspace.where(:id => 1).limit(2).map {|w| { :key => "workspaces", :id => w.id.to_s } })
+        expect(structure[:workspaces].keys).to eq(%w[1])
       end
     end
 
     describe "includes" do
       it "reads allowed includes from the presenter" do
         result = @presenter_collection.presenting("workspaces", :params => { :include => "drop table,tasks,users" }) { Workspace.order('id desc') }
-        result.keys.should =~ [:count, :workspaces, :tasks, :results]
+        expect(result.keys).to match_array([:count, :workspaces, :tasks, :results])
 
         result = @presenter_collection.presenting("workspaces", :params => { :include => "foo,tasks,lead_user" }) { Workspace.order('id desc') }
-        result.keys.should =~ [:count, :workspaces, :tasks, :users, :results]
+        expect(result.keys).to match_array([:count, :workspaces, :tasks, :users, :results])
       end
 
       it "allows the allowed includes list to have different json names and association names" do
         result = @presenter_collection.presenting("tasks",
           :params => { :include => "other_tasks" }) { Task.order('id desc') }
-        result[:tasks].should be_present
-        result[:other_tasks].should be_present
+        expect(result[:tasks]).to be_present
+        expect(result[:other_tasks]).to be_present
       end
 
       it "defaults to not include any allowed includes" do
         tasked_workspace = Task.first
         result = @presenter_collection.presenting("workspaces", :max_per_page => 2) { Workspace.where(:id => tasked_workspace.workspace_id) }
-        result[:workspaces].keys.should == [ tasked_workspace.workspace_id.to_s ]
-        result[:tasks].should be_nil
+        expect(result[:workspaces].keys).to eq([ tasked_workspace.workspace_id.to_s ])
+        expect(result[:tasks]).to be_nil
       end
 
       it "loads has_many associations and returns them when requested" do
         result = @presenter_collection.presenting("workspaces", :params => { :include => "tasks" }, :max_per_page => 2) { Workspace.where(:id => 1) }
-        result[:tasks].keys.should =~ Workspace.first.tasks.map(&:id).map(&:to_s)
-        result[:workspaces]["1"][:task_ids].should =~ Workspace.first.tasks.map(&:id).map(&:to_s)
+        expect(result[:tasks].keys).to match_array(Workspace.first.tasks.map(&:id).map(&:to_s))
+        expect(result[:workspaces]["1"][:task_ids]).to match_array(Workspace.first.tasks.map(&:id).map(&:to_s))
       end
 
       it "returns appropriate fields" do
         result = @presenter_collection.presenting("workspaces",
                                                   :params => { :include => "tasks" },
                                                   :max_per_page => 2) { Workspace.where(:id => 1) }
-        result[:workspaces].values.first.should have_key(:description)
-        result[:tasks].values.first.should have_key(:name)
+        expect(result[:workspaces].values.first).to have_key(:description)
+        expect(result[:tasks].values.first).to have_key(:name)
       end
 
       it "loads belongs_tos and returns them when requested" do
         result = @presenter_collection.presenting("tasks", :params => { :include => "workspace" }, :max_per_page => 2) { Task.where(:id => 1) }
-        result[:workspaces].keys.should == %w[1]
+        expect(result[:workspaces].keys).to eq(%w[1])
       end
 
       it "doesn't return nils when belong_tos are missing" do
         t = Task.first
         t.update_attribute :workspace, nil
-        t.reload.workspace.should be_nil
+        expect(t.reload.workspace).to be_nil
         result = @presenter_collection.presenting("tasks", :params => { :include => "workspace" }, :max_per_page => 2) { Task.where(:id => t.id) }
-        result[:tasks].keys.should == [ t.id.to_s ]
-        result[:workspaces].should eq({})
-        result.keys.should =~ [:tasks, :workspaces, :count, :results]
+        expect(result[:tasks].keys).to eq([ t.id.to_s ])
+        expect(result[:workspaces]).to eq({})
+        expect(result.keys).to match_array([:tasks, :workspaces, :count, :results])
       end
 
       it "returns sensible data when including something of the same type as the primary model" do
         result = @presenter_collection.presenting("tasks", :params => { :include => "sub_tasks" }) { Task.where(:id => 2) }
         sub_task_ids = Task.find(2).sub_tasks.map(&:id).map(&:to_s)
-        result[:tasks].keys.should =~ sub_task_ids + ["2"]
-        result[:tasks]["2"][:sub_task_ids].should == sub_task_ids               # The primary should have a sub_story_ids array.
-        result[:tasks][sub_task_ids.first][:sub_task_ids].should_not be_present # Sub stories should not have a sub_story_ids array.
+        expect(result[:tasks].keys).to match_array(sub_task_ids + ["2"])
+        expect(result[:tasks]["2"][:sub_task_ids]).to eq(sub_task_ids)               # The primary should have a sub_story_ids array.
+        expect(result[:tasks][sub_task_ids.first][:sub_task_ids]).not_to be_present # Sub stories should not have a sub_story_ids array.
       end
 
       it "includes requested includes even when all records are filtered" do
         result = @presenter_collection.presenting("workspaces", :params => { :only => "not an id", :include => "not an include,tasks" }) { Workspace.order("id desc") }
-        result[:workspaces].length.should == 0
-        result[:tasks].length.should == 0
+        expect(result[:workspaces].length).to eq(0)
+        expect(result[:tasks].length).to eq(0)
       end
 
       it "includes requested includes even when the scope has no records" do
-        Workspace.where(:id => 123456789).should be_empty
+        expect(Workspace.where(:id => 123456789)).to be_empty
         result = @presenter_collection.presenting("workspaces", :params => { :include => "not an include,tasks" }) { Workspace.where(:id => 123456789) }
-        result[:workspaces].length.should == 0
-        result[:tasks].length.should == 0
+        expect(result[:workspaces].length).to eq(0)
+        expect(result[:tasks].length).to eq(0)
       end
 
       it "preloads associations when they are full model-level associations" do
         # Here, primary_maven is a method on Workspace, not a true association.
         mock(@presenter_collection).preload(anything, [:tasks])
         result = @presenter_collection.presenting("workspaces", :params => { :include => "tasks" }) { Workspace.order('id desc') }
-        result[:tasks].length.should > 0
+        expect(result[:tasks].length).to be > 0
       end
 
       it "works with model methods that load records (but without preloading)" do
         result = @presenter_collection.presenting("workspaces", :params => { :include => "lead_user" }) { Workspace.order('id desc') }
-        result[:workspaces][Workspace.first.id.to_s].should be_present
-        result[:users][Workspace.first.lead_user.id.to_s].should be_present
+        expect(result[:workspaces][Workspace.first.id.to_s]).to be_present
+        expect(result[:users][Workspace.first.lead_user.id.to_s]).to be_present
       end
 
       it "can accept a lambda for the association and uses that when present" do
         result = @presenter_collection.presenting("users", :params => { :include => "odd_workspaces" }) { User.where(:id => 1) }
-        result[:odd_workspaces][Workspace.first.id.to_s].should be_present
-        result[:users][Workspace.first.lead_user.id.to_s].should be_present
+        expect(result[:odd_workspaces][Workspace.first.id.to_s]).to be_present
+        expect(result[:users][Workspace.first.lead_user.id.to_s]).to be_present
       end
 
       describe "restricted associations" do
         it "does apply includes that are restricted to only queries in an only query" do
           t = Task.first
           result = @presenter_collection.presenting("tasks", :params => { :include => "restricted", :only => t.id.to_s }, :max_per_page => 2) { Task.where(:id => t.id) }
-          result[:tasks][t.id.to_s].keys.should include(:restricted_id)
-          result.keys.should include(:restricted_associations)
+          expect(result[:tasks][t.id.to_s].keys).to include(:restricted_id)
+          expect(result.keys).to include(:restricted_associations)
         end
 
         it "does not apply includes that are restricted to only queries in a non-only query" do
           t = Task.first
           result = @presenter_collection.presenting("tasks", :params => { :include => "restricted" }, :max_per_page => 2) { Task.where(:id => t.id) }
 
-          result[:tasks][t.id.to_s].keys.should_not include(:restricted_id)
-          result.keys.should_not include(:restricted_associations)
+          expect(result[:tasks][t.id.to_s].keys).not_to include(:restricted_id)
+          expect(result.keys).not_to include(:restricted_associations)
         end
       end
 
       describe "polymorphic associations" do
         it "works with polymorphic associations" do
           result = @presenter_collection.presenting("posts", :params => { :include => "subject" }) { Post.order('id desc') }
-          result[:posts][Post.first.id.to_s].should be_present
-          result[:workspaces][Workspace.first.id.to_s].should be_present
-          result[:tasks][Task.first.id.to_s].should be_present
+          expect(result[:posts][Post.first.id.to_s]).to be_present
+          expect(result[:workspaces][Workspace.first.id.to_s]).to be_present
+          expect(result[:tasks][Task.first.id.to_s]).to be_present
         end
 
         it "does not return an empty hash when none are found" do
           result = @presenter_collection.presenting("posts", :params => { :include => "subject" }) { Post.where(:id => nil) }
-          result.should have_key(:posts)
-          result.should_not have_key(:workspaces)
-          result.should_not have_key(:tasks)
+          expect(result).to have_key(:posts)
+          expect(result).not_to have_key(:workspaces)
+          expect(result).not_to have_key(:tasks)
         end
       end
     end
@@ -313,7 +313,7 @@ describe Brainstem::PresenterCollection do
     describe "handling of only" do
       it "accepts params[:only] as a list of ids to limit to" do
         result = @presenter_collection.presenting("workspaces", :params => { :only => Workspace.limit(2).pluck(:id).join(",") }) { Workspace.order("id desc") }
-        result[:workspaces].keys.should match_array(Workspace.limit(2).pluck(:id).map(&:to_s))
+        expect(result[:workspaces].keys).to match_array(Workspace.limit(2).pluck(:id).map(&:to_s))
       end
 
       it "does not paginate only requests" do
@@ -323,15 +323,15 @@ describe Brainstem::PresenterCollection do
 
       it "escapes ids" do
         result = @presenter_collection.presenting("workspaces", :params => { :only => "#{Workspace.first.id}foo,;drop tables;,#{Workspace.first.id}" }) { Workspace.order("id desc") }
-        result[:workspaces].length.should == 1
+        expect(result[:workspaces].length).to eq(1)
       end
 
       it "only runs when it receives ids" do
         result = @presenter_collection.presenting("workspaces", :params => { :only => "" }) { Workspace.order("id desc") }
-        result[:workspaces].length.should > 1
+        expect(result[:workspaces].length).to be > 1
 
         result = @presenter_collection.presenting("workspaces", :params => { :only => "1" }) { Workspace.order("id desc") }
-        result[:workspaces].length.should <= 1
+        expect(result[:workspaces].length).to be <= 1
       end
     end
 
@@ -343,67 +343,67 @@ describe Brainstem::PresenterCollection do
 
       it "limits records to those matching given filters" do
         result = @presenter_collection.presenting("workspaces", :params => { :owned_by => bob.id.to_s }) { Workspace.order("id desc") } # hit the API, filtering on owned_by:bob
-        result[:workspaces].should be_present
-        result[:workspaces].keys.all? {|id| bob_workspaces_ids.map(&:to_s).include?(id) }.should be_true # all of the returned workspaces should contain bob
+        expect(result[:workspaces]).to be_present
+        expect(result[:workspaces].keys.all? {|id| bob_workspaces_ids.map(&:to_s).include?(id) }).to be_truthy # all of the returned workspaces should contain bob
       end
 
       it "returns all records if filters are not given" do
         result = @presenter_collection.presenting("workspaces") { Workspace.order("id desc") } # hit the API again, this time not filtering on anything
-        result[:workspaces].keys.all? {|id| bob_workspaces_ids.map(&:to_s).include?(id) }.should be_false # the returned workspaces no longer all contain bob
+        expect(result[:workspaces].keys.all? {|id| bob_workspaces_ids.map(&:to_s).include?(id) }).to be_falsey # the returned workspaces no longer all contain bob
       end
 
       it "ignores unknown filters" do
         result = @presenter_collection.presenting("workspaces", :params => { :wut => "is this?" }) { Workspace.order("id desc") }
-        result[:workspaces].keys.all? {|id| bob_workspaces_ids.map(&:to_s).include?(id) }.should be_false
+        expect(result[:workspaces].keys.all? {|id| bob_workspaces_ids.map(&:to_s).include?(id) }).to be_falsey
       end
 
       it "limits records to those matching all given filters" do
         result = @presenter_collection.presenting("workspaces", :params => { :owned_by => bob.id.to_s, :title => "bob workspace 1" }) { Workspace.order("id desc") } # try two filters
-        result[:results].first[:id].should == Workspace.where(:title => "bob workspace 1").first.id.to_s
+        expect(result[:results].first[:id]).to eq(Workspace.where(:title => "bob workspace 1").first.id.to_s)
       end
 
       it "converts boolean parameters from strings to booleans" do
         WorkspacePresenter.filter(:owned_by_bob) { |scope, boolean| boolean ? scope.where(:user_id => bob.id) : scope.where(:user_id => jane.id) }
         result = @presenter_collection.presenting("workspaces", :params => { :owned_by_bob => "false" }) { Workspace.where(nil) }
-        result[:workspaces].values.find { |workspace| workspace[:title].include?("jane") }.should be
-        result[:workspaces].values.find { |workspace| workspace[:title].include?("bob") }.should_not be
+        expect(result[:workspaces].values.find { |workspace| workspace[:title].include?("jane") }).to be
+        expect(result[:workspaces].values.find { |workspace| workspace[:title].include?("bob") }).not_to be
       end
 
       it "ensures arguments are strings if they are not arrays" do
         filter_was_run = false
         WorkspacePresenter.filter(:owned_by_bob) do |scope, string|
           filter_was_run = true
-          string.should be_a(String)
+          expect(string).to be_a(String)
           scope
         end
         @presenter_collection.presenting("workspaces", :params => { :owned_by_bob => { :wut => "is this?" } }) { Workspace.where(nil) }
-        filter_was_run.should be_true
+        expect(filter_was_run).to be_truthy
       end
 
       it "preserves array arguments" do
         filter_was_run = false
         WorkspacePresenter.filter(:owned_by_bob) do |scope, array|
           filter_was_run = true
-          array.should be_a(Array)
+          expect(array).to be_a(Array)
           scope
         end
         @presenter_collection.presenting("workspaces", :params => { :owned_by_bob => [1, 2] }) { Workspace.where(nil) }
-        filter_was_run.should be_true
+        expect(filter_was_run).to be_truthy
       end
 
       it "allows filters to be called with false as an argument" do
         WorkspacePresenter.filter(:nothing) { |scope, bool| bool ? scope.where(:id => nil) : scope }
         result = @presenter_collection.presenting("workspaces", :params => { :nothing => "true" }) { Workspace.where(nil) }
-        result[:workspaces].length.should eq(0)
+        expect(result[:workspaces].length).to eq(0)
         result = @presenter_collection.presenting("workspaces", :params => { :nothing => "false" }) { Workspace.where(nil) }
-        result[:workspaces].length.should_not eq(0)
+        expect(result[:workspaces].length).not_to eq(0)
       end
 
       it "passes colon separated params through as a string" do
         WorkspacePresenter.filter(:between) { |scope, a_and_b|
           a, b = a_and_b.split(':')
-          a.should == "1"
-          b.should == "10"
+          expect(a).to eq("1")
+          expect(b).to eq("10")
           scope
         }
 
@@ -419,32 +419,32 @@ describe Brainstem::PresenterCollection do
 
         it "applies the filter when it is not requested" do
           result = @presenter_collection.presenting("workspaces") { Workspace.order('id desc') }
-          result[:workspaces].keys.should match_array(bob.workspaces.map(&:id).map(&:to_s))
+          expect(result[:workspaces].keys).to match_array(bob.workspaces.map(&:id).map(&:to_s))
         end
 
         it "allows falsy defaults" do
           WorkspacePresenter.filter(:include_early_workspaces, :default => false) { |scope, bool| bool ? scope : scope.where("id > 3") }
           result = @presenter_collection.presenting("workspaces") { Workspace.unscoped }
-          result[:workspaces]["2"].should_not be_present
+          expect(result[:workspaces]["2"]).not_to be_present
           result = @presenter_collection.presenting("workspaces", :params => { :include_early_workspaces => "true" }) { Workspace.unscoped }
-          result[:workspaces]["2"].should be_present
+          expect(result[:workspaces]["2"]).to be_present
         end
 
         it "allows defaults to be skipped if :apply_default_filters is false" do
           WorkspacePresenter.filter(:include_early_workspaces, :default => false) { |scope, bool| bool ? scope : scope.where("id > 3") }
           result = @presenter_collection.presenting("workspaces", :apply_default_filters => true) { Workspace.unscoped }
-          result[:workspaces]["2"].should_not be_present
+          expect(result[:workspaces]["2"]).not_to be_present
           result = @presenter_collection.presenting("workspaces", :apply_default_filters => false) { Workspace.unscoped }
-          result[:workspaces]["2"].should be_present
+          expect(result[:workspaces]["2"]).to be_present
         end
 
         it "allows the default value to be overridden" do
           result = @presenter_collection.presenting("workspaces", :params => { :owner => jane.id.to_s }) { Workspace.order('id desc') }
-          result[:workspaces].keys.should match_array(jane.workspaces.map(&:id).map(&:to_s))
+          expect(result[:workspaces].keys).to match_array(jane.workspaces.map(&:id).map(&:to_s))
 
           WorkspacePresenter.filter(:include_early_workspaces, :default => true) { |scope, bool| bool ? scope : scope.where("id > 3") }
           result = @presenter_collection.presenting("workspaces", :params => { :include_early_workspaces => "false" }) { Workspace.unscoped }
-          result[:workspaces]["2"].should_not be_present
+          expect(result[:workspaces]["2"]).not_to be_present
         end
       end
 
@@ -459,27 +459,27 @@ describe Brainstem::PresenterCollection do
 
         it "calls the named scope with default arguments" do
           result = @presenter_collection.presenting("workspaces") { Workspace.where(nil) }
-          result[:workspaces].keys.should eq(bob.workspaces.pluck(:id).map(&:to_s))
+          expect(result[:workspaces].keys).to eq(bob.workspaces.pluck(:id).map(&:to_s))
         end
 
         it "calls the named scope with given arguments" do
           result = @presenter_collection.presenting("workspaces", :params => { :owned_by => jane.id.to_s }) { Workspace.where(nil) }
-          result[:workspaces].keys.should eq(jane.workspaces.pluck(:id).map(&:to_s))
+          expect(result[:workspaces].keys).to eq(jane.workspaces.pluck(:id).map(&:to_s))
         end
 
         it "can use filters without lambdas in the presenter or model, but behaves strangely when false is given" do
           WorkspacePresenter.filter(:numeric_description)
 
           result = @presenter_collection.presenting("workspaces") { Workspace.where(nil) }
-          result[:workspaces].keys.should eq(%w[1 2 3 4])
+          expect(result[:workspaces].keys).to eq(%w[1 2 3 4])
 
           result = @presenter_collection.presenting("workspaces", :params => { :numeric_description => "true" }) { Workspace.where(nil) }
-          result[:workspaces].keys.should eq(%w[2 4])
+          expect(result[:workspaces].keys).to eq(%w[2 4])
 
           # This is probably not the behavior that the developer or user intends.  You should always use a one-argument lambda in your
           # model scope declaration!
           result = @presenter_collection.presenting("workspaces", :params => { :numeric_description => "false" }) { Workspace.where(nil) }
-          result[:workspaces].keys.should eq(%w[2 4])
+          expect(result[:workspaces].keys).to eq(%w[2 4])
         end
       end
     end
@@ -495,8 +495,8 @@ describe Brainstem::PresenterCollection do
         context "and a search request is made" do
           it "calls the search method and maintains the resulting order" do
             result = @presenter_collection.presenting("workspaces", :params => { :search => "blah" }) { Workspace.order("id asc") }
-            result[:workspaces].keys.should eq(%w[5 3])
-            result[:count].should eq(2)
+            expect(result[:workspaces].keys).to eq(%w[5 3])
+            expect(result[:count]).to eq(2)
           end
 
           it "does not apply filters" do
@@ -529,22 +529,22 @@ describe Brainstem::PresenterCollection do
               false
             end
 
-            lambda {
+            expect {
               @presenter_collection.presenting("workspaces", :params => { :search => "blah" }) { Workspace.unscoped }
-            }.should raise_error(Brainstem::SearchUnavailableError)
+            }.to raise_error(Brainstem::SearchUnavailableError)
           end
 
           describe "passing options to the search block" do
             it "passes the search method, the search string, includes, order, and paging options" do
               WorkspacePresenter.filter(:owned_by) { |scope| scope }
               WorkspacePresenter.search do |string, options|
-                string.should == "blah"
-                options[:include].should == ["tasks", "lead_user"]
-                options[:owned_by].should == false
-                options[:order][:sort_order].should == "updated_at"
-                options[:order][:direction].should == "desc"
-                options[:page].should == 2
-                options[:per_page].should == 5
+                expect(string).to eq("blah")
+                expect(options[:include]).to eq(["tasks", "lead_user"])
+                expect(options[:owned_by]).to eq(false)
+                expect(options[:order][:sort_order]).to eq("updated_at")
+                expect(options[:order][:direction]).to eq("desc")
+                expect(options[:page]).to eq(2)
+                expect(options[:per_page]).to eq(5)
                 [[1], 1] # returned ids, count - not testing this in this set of specs
               end
 
@@ -554,7 +554,7 @@ describe Brainstem::PresenterCollection do
             describe "includes" do
               it "throws out requested inlcudes that the presenter does not have associations for" do
                 WorkspacePresenter.search do |string, options|
-                  options[:include].should == []
+                  expect(options[:include]).to eq([])
                   [[1], 1]
                 end
 
@@ -566,7 +566,7 @@ describe Brainstem::PresenterCollection do
               it "passes through the default filters if no filter is requested" do
                 WorkspacePresenter.filter(:owned_by, :default => true) { |scope| scope }
                 WorkspacePresenter.search do |string, options|
-                  options[:owned_by].should == true
+                  expect(options[:owned_by]).to eq(true)
                   [[1], 1]
                 end
 
@@ -575,7 +575,7 @@ describe Brainstem::PresenterCollection do
 
               it "throws out requested filters that the presenter does not have" do
                 WorkspacePresenter.search do |string, options|
-                  options[:highest_rated].should be_nil
+                  expect(options[:highest_rated]).to be_nil
                   [[1], 1]
                 end
 
@@ -585,7 +585,7 @@ describe Brainstem::PresenterCollection do
               it "does not pass through existing non-default filters that are not requested" do
                 WorkspacePresenter.filter(:owned_by) { |scope| scope }
                 WorkspacePresenter.search do |string, options|
-                  options.has_key?(:owned_by).should == false
+                  expect(options.has_key?(:owned_by)).to eq(false)
                   [[1], 1]
                 end
 
@@ -597,8 +597,8 @@ describe Brainstem::PresenterCollection do
               it "passes through the default sort order if no order is requested" do
                 WorkspacePresenter.default_sort_order("description:desc")
                 WorkspacePresenter.search do |string, options|
-                  options[:order][:sort_order].should == "description"
-                  options[:order][:direction].should == "desc"
+                  expect(options[:order][:sort_order]).to eq("description")
+                  expect(options[:order][:direction]).to eq("desc")
                   [[1], 1]
                 end
 
@@ -607,8 +607,8 @@ describe Brainstem::PresenterCollection do
 
               it "makes the sort order 'updated_at:desc' if the requested order doesn't match an existing sort order and there is no default" do
                 WorkspacePresenter.search do |string, options|
-                  options[:order][:sort_order].should == "updated_at"
-                  options[:order][:direction].should == "desc"
+                  expect(options[:order][:sort_order]).to eq("updated_at")
+                  expect(options[:order][:direction]).to eq("desc")
                   [[1], 1]
                 end
 
@@ -619,8 +619,8 @@ describe Brainstem::PresenterCollection do
             describe "pagination" do
               it "passes through limit and offset if they are requested" do
                 WorkspacePresenter.search do |string, options|
-                  options[:limit].should == 1
-                  options[:offset].should == 2
+                  expect(options[:limit]).to eq(1)
+                  expect(options[:offset]).to eq(2)
                   [[1], 1]
                 end
 
@@ -629,10 +629,10 @@ describe Brainstem::PresenterCollection do
 
               it "passes through only limit and offset if all pagination options are requested" do
                 WorkspacePresenter.search do |string, options|
-                  options[:limit].should == 1
-                  options[:offset].should == 2
-                  options[:per_page].should == nil
-                  options[:page].should == nil
+                  expect(options[:limit]).to eq(1)
+                  expect(options[:offset]).to eq(2)
+                  expect(options[:per_page]).to eq(nil)
+                  expect(options[:page]).to eq(nil)
                   [[1], 1]
                 end
 
@@ -641,10 +641,10 @@ describe Brainstem::PresenterCollection do
 
               it "passes through page and per_page when limit not present" do
                 WorkspacePresenter.search do |string, options|
-                  options[:limit].should == nil
-                  options[:offset].should == nil
-                  options[:per_page].should == 3
-                  options[:page].should == 4
+                  expect(options[:limit]).to eq(nil)
+                  expect(options[:offset]).to eq(nil)
+                  expect(options[:per_page]).to eq(3)
+                  expect(options[:page]).to eq(4)
                   [[1], 1]
                 end
 
@@ -653,10 +653,10 @@ describe Brainstem::PresenterCollection do
 
               it "passes through page and per_page when offset not present" do
                 WorkspacePresenter.search do |string, options|
-                  options[:limit].should == nil
-                  options[:offset].should == nil
-                  options[:per_page].should == 3
-                  options[:page].should == 4
+                  expect(options[:limit]).to eq(nil)
+                  expect(options[:offset]).to eq(nil)
+                  expect(options[:per_page]).to eq(3)
+                  expect(options[:page]).to eq(4)
                   [[1], 1]
                 end
 
@@ -665,10 +665,10 @@ describe Brainstem::PresenterCollection do
 
               it "passes through page and per_page by default" do
                 WorkspacePresenter.search do |string, options|
-                  options[:limit].should == nil
-                  options[:offset].should == nil
-                  options[:per_page].should == 20
-                  options[:page].should == 1
+                  expect(options[:limit]).to eq(nil)
+                  expect(options[:offset]).to eq(nil)
+                  expect(options[:per_page]).to eq(20)
+                  expect(options[:page]).to eq(1)
                   [[1], 1]
                 end
 
@@ -681,7 +681,7 @@ describe Brainstem::PresenterCollection do
         context "and there is no search request" do
           it "does not call the search method" do
             result = @presenter_collection.presenting("workspaces") { Workspace.order("id asc") }
-            result[:workspaces].keys.should eq(Workspace.pluck(:id).map(&:to_s))
+            expect(result[:workspaces].keys).to eq(Workspace.pluck(:id).map(&:to_s))
           end
         end
       end
@@ -690,7 +690,7 @@ describe Brainstem::PresenterCollection do
         context "and a search request is made" do
           it "returns as if there was no search" do
             result = @presenter_collection.presenting("workspaces", :params => { :search => "blah" }) { Workspace.order("id asc") }
-            result[:workspaces].keys.should eq(Workspace.pluck(:id).map(&:to_s))
+            expect(result[:workspaces].keys).to eq(Workspace.pluck(:id).map(&:to_s))
           end
         end
       end
@@ -700,12 +700,12 @@ describe Brainstem::PresenterCollection do
       context "when there is no sort provided" do
         it "returns an empty array when there are no objects" do
           result = @presenter_collection.presenting("workspaces") { Workspace.where(:id => nil) }
-          result.should eq(:count => 0, :workspaces => {}, :results => [])
+          expect(result).to eq(:count => 0, :workspaces => {}, :results => [])
         end
 
         it "falls back to the object's sort order when nothing is provided" do
           result = @presenter_collection.presenting("workspaces") { Workspace.where(:id => [1, 3]) }
-          result[:workspaces].keys.should == %w[1 3]
+          expect(result[:workspaces].keys).to eq(%w[1 3])
         end
       end
 
@@ -713,28 +713,28 @@ describe Brainstem::PresenterCollection do
         WorkspacePresenter.sort_order(:description, "workspaces.description")
         WorkspacePresenter.default_sort_order("description:desc")
         result = @presenter_collection.presenting("workspaces") { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(c b a 3 2 1))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(c b a 3 2 1))
       end
 
       it "allows default ordering ascending" do
         WorkspacePresenter.sort_order(:description, "workspaces.description")
         WorkspacePresenter.default_sort_order("description:asc")
         result = @presenter_collection.presenting("workspaces") { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(1 2 3 a b c))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(1 2 3 a b c))
       end
 
       it "applies orders that match the default order" do
         WorkspacePresenter.sort_order(:description, "workspaces.description")
         WorkspacePresenter.default_sort_order("description:desc")
         result = @presenter_collection.presenting("workspaces", :params => { :order => "description:desc"} ) { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(c b a 3 2 1))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(c b a 3 2 1))
       end
 
       it "applies orders that conflict with the default order" do
         WorkspacePresenter.sort_order(:description, "workspaces.description")
         WorkspacePresenter.default_sort_order("description:desc")
         result = @presenter_collection.presenting("workspaces", :params => { :order => "description:asc"} ) { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(1 2 3 a b c))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(1 2 3 a b c))
       end
 
       it "cleans the params" do
@@ -742,11 +742,11 @@ describe Brainstem::PresenterCollection do
         WorkspacePresenter.default_sort_order("description:desc")
 
         result = @presenter_collection.presenting("workspaces", :params => { :order => "updated_at:drop table" }) { Workspace.where("id is not null") }
-        result.keys.should =~ [:count, :workspaces, :results]
+        expect(result.keys).to match_array([:count, :workspaces, :results])
 
         result = @presenter_collection.presenting("workspaces", :params => { :order => "drop table:desc" }) { Workspace.where("id is not null") }
-        result.keys.should =~ [:count, :workspaces, :results]
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(c b a 3 2 1))
+        expect(result.keys).to match_array([:count, :workspaces, :results])
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(c b a 3 2 1))
       end
 
       it "can take a proc" do
@@ -755,22 +755,22 @@ describe Brainstem::PresenterCollection do
 
         # Default
         result = @presenter_collection.presenting("workspaces") { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(a 1 b 2 c 3))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(a 1 b 2 c 3))
 
         # Asc
         result = @presenter_collection.presenting("workspaces", :params => { :order => "id:asc" }) { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(a 1 b 2 c 3))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(a 1 b 2 c 3))
 
         # Desc
         result = @presenter_collection.presenting("workspaces", :params => { :order => "id:desc" }) { Workspace.where("id is not null") }
-        result[:results].map {|i| result[:workspaces][i[:id]][:description] }.should eq(%w(3 c 2 b 1 a))
+        expect(result[:results].map {|i| result[:workspaces][i[:id]][:description] }).to eq(%w(3 c 2 b 1 a))
       end
     end
 
     describe "the :as param" do
       it "determines the chosen top-level key name" do
         result = @presenter_collection.presenting("workspaces", :as => :my_workspaces) { Workspace.where(:id => 1) }
-        result.keys.should eq([:count, :my_workspaces, :results])
+        expect(result.keys).to eq([:count, :my_workspaces, :results])
       end
     end
 
@@ -779,16 +779,16 @@ describe Brainstem::PresenterCollection do
         WorkspacePresenter.filter(:owned_by) { |scope, user_id| scope.owned_by(user_id.to_i) }
 
         result = @presenter_collection.presenting("workspaces") { Workspace.where(:id => 1) }
-        result[:count].should == 1
+        expect(result[:count]).to eq(1)
 
         result = @presenter_collection.presenting("workspaces") { Workspace.unscoped }
-        result[:count].should == Workspace.count
+        expect(result[:count]).to eq(Workspace.count)
 
         result = @presenter_collection.presenting("workspaces", :params => { :owned_by => bob.to_param }) { Workspace.unscoped }
-        result[:count].should == Workspace.owned_by(bob.to_param).count
+        expect(result[:count]).to eq(Workspace.owned_by(bob.to_param).count)
 
         result = @presenter_collection.presenting("workspaces", :params => { :owned_by => bob.to_param }) { Workspace.group(:id) }
-        result[:count].should == Workspace.owned_by(bob.to_param).count
+        expect(result[:count]).to eq(Workspace.owned_by(bob.to_param).count)
       end
     end
   end
@@ -805,25 +805,25 @@ describe Brainstem::PresenterCollection do
       end
 
       it "returns the presenter for a given class" do
-        Brainstem.presenter_collection("v1").for(Array).should be_a(V1::ArrayPresenter)
+        expect(Brainstem.presenter_collection("v1").for(Array)).to be_a(V1::ArrayPresenter)
       end
 
       it "returns nil when given nil" do
-        Brainstem.presenter_collection("v1").for(nil).should be_nil
+        expect(Brainstem.presenter_collection("v1").for(nil)).to be_nil
       end
 
       it "returns nil when a given class has no presenter" do
-        Brainstem.presenter_collection("v1").for(String).should be_nil
+        expect(Brainstem.presenter_collection("v1").for(String)).to be_nil
       end
 
       it "uses the default namespace when the passed namespace is nil" do
-        Brainstem.presenter_collection.should eq(Brainstem.presenter_collection(nil))
+        expect(Brainstem.presenter_collection).to eq(Brainstem.presenter_collection(nil))
       end
     end
 
     describe "for! method" do
       it "raises if there is no presenter for the given class" do
-        lambda{ Brainstem.presenter_collection("v1").for!(String) }.should raise_error(ArgumentError)
+        expect{ Brainstem.presenter_collection("v1").for!(String) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -10,18 +10,18 @@ describe Brainstem::Presenter do
 
       it "records itself as the presenter for the named class as a string" do
         @klass.presents "String"
-        Brainstem.presenter_collection.for(String).should be_a(@klass)
+        expect(Brainstem.presenter_collection.for(String)).to be_a(@klass)
       end
 
       it "records itself as the presenter for the given class" do
         @klass.presents String
-        Brainstem.presenter_collection.for(String).should be_a(@klass)
+        expect(Brainstem.presenter_collection.for(String)).to be_a(@klass)
       end
 
       it "records itself as the presenter for the named classes" do
         @klass.presents String, Array
-        Brainstem.presenter_collection.for(String).should be_a(@klass)
-        Brainstem.presenter_collection.for(Array).should be_a(@klass)
+        expect(Brainstem.presenter_collection.for(String)).to be_a(@klass)
+        expect(Brainstem.presenter_collection.for(Array)).to be_a(@klass)
       end
     end
 
@@ -33,12 +33,12 @@ describe Brainstem::Presenter do
 
       it "uses the closest module name as the presenter namespace" do
         V1::SomePresenter.presents String
-        Brainstem.presenter_collection(:v1).for(String).should be_a(V1::SomePresenter)
+        expect(Brainstem.presenter_collection(:v1).for(String)).to be_a(V1::SomePresenter)
       end
 
       it "does not map namespaced presenters into the default namespace" do
         V1::SomePresenter.presents String
-        Brainstem.presenter_collection.for(String).should be_nil
+        expect(Brainstem.presenter_collection.for(String)).to be_nil
       end
     end
 
@@ -57,10 +57,10 @@ describe Brainstem::Presenter do
       end
 
       it "includes and extends the given module" do
-        lambda { @klass.new.call_helper }.should raise_error
+        expect { @klass.new.call_helper }.to raise_error
         @klass.helper @helper
-        @klass.new.call_helper.should == "I work"
-        @klass.foo.should == "I work"
+        expect(@klass.new.call_helper).to eq("I work")
+        expect(@klass.foo).to eq("I work")
       end
     end
 
@@ -71,13 +71,13 @@ describe Brainstem::Presenter do
 
       it "creates an entry in the filters class ivar" do
         @klass.filter(:foo, :default => true) { 1 }
-        @klass.filters[:foo][0].should eq({"default" => true})
-        @klass.filters[:foo][1].should be_a(Proc)
+        expect(@klass.filters[:foo][0]).to eq({"default" => true})
+        expect(@klass.filters[:foo][1]).to be_a(Proc)
       end
 
       it "accepts names without blocks" do
         @klass.filter(:foo)
-        @klass.filters[:foo][1].should be_nil
+        expect(@klass.filters[:foo][1]).to be_nil
       end
     end
 
@@ -88,7 +88,7 @@ describe Brainstem::Presenter do
 
       it "creates an entry in the search class ivar" do
         @klass.search do end
-        @klass.search_block.should be_a(Proc)
+        expect(@klass.search_block).to be_a(Proc)
       end
     end
   end
@@ -112,8 +112,8 @@ describe Brainstem::Presenter do
 
       it "outputs the associated object's id and type" do
         data = @presenter.present_and_post_process(@post)
-        data[:id].should eq(@post.id.to_s)
-        data[:body].should eq(@post.body)
+        expect(data[:id]).to eq(@post.id.to_s)
+        expect(data[:body]).to eq(@post.body)
       end
     end
 
@@ -137,12 +137,12 @@ describe Brainstem::Presenter do
         iso8601_date = /\d{4}-\d{2}-\d{2}/
 
         struct = TimePresenter.new.present_and_post_process("something")
-        struct[:time].should =~ iso8601_time
-        struct[:date].should =~ iso8601_date
-        struct[:recursion][:time].should =~ iso8601_time
-        struct[:recursion][:something].first.should =~ iso8601_time
-        struct[:recursion][:something].last.should == :else
-        struct[:recursion][:foo].should == :bar
+        expect(struct[:time]).to match(iso8601_time)
+        expect(struct[:date]).to match(iso8601_date)
+        expect(struct[:recursion][:time]).to match(iso8601_time)
+        expect(struct[:recursion][:something].first).to match(iso8601_time)
+        expect(struct[:recursion][:something].last).to eq(:else)
+        expect(struct[:recursion][:foo]).to eq(:bar)
       end
     end
 
@@ -166,14 +166,14 @@ describe Brainstem::Presenter do
 
       it "outputs the associated object's id and type" do
         data = @presenter.present_and_post_process(@post)
-        data[:subject_id].should eq(@post.subject_id.to_s)
-        data[:subject_type].should eq(@post.subject_type)
+        expect(data[:subject_id]).to eq(@post.subject_id.to_s)
+        expect(data[:subject_type]).to eq(@post.subject_type)
       end
 
       it "outputs custom names for an associated object's id and type" do
         data = @presenter.present_and_post_process(@post)
-        data[:another_subject_id].should eq(@post.subject_id.to_s)
-        data[:another_subject_type].should eq(@post.subject_type)
+        expect(data[:another_subject_id]).to eq(@post.subject_id.to_s)
+        expect(data[:another_subject_type]).to eq(@post.subject_type)
       end
     end
 
@@ -202,43 +202,43 @@ describe Brainstem::Presenter do
 
       it "should not convert or return non-included associations, but should return <association>_id for belongs_to relationships, plus all fields" do
         json = @presenter.present_and_post_process(@workspace, [])
-        json.keys.should =~ [:id, :updated_at, :something_id, :user_id]
+        expect(json.keys).to match_array([:id, :updated_at, :something_id, :user_id])
       end
 
       it "should convert requested has_many associations (includes) into the <association>_ids format" do
-        @workspace.tasks.length.should > 0
-        @presenter.present_and_post_process(@workspace, ["tasks"])[:task_ids].should =~ @workspace.tasks.map(&:id).map(&:to_s)
+        expect(@workspace.tasks.length).to be > 0
+        expect(@presenter.present_and_post_process(@workspace, ["tasks"])[:task_ids]).to match_array(@workspace.tasks.map(&:id).map(&:to_s))
       end
 
       it "should convert requested belongs_to and has_one associations into the <association>_id format when requested" do
-        @presenter.present_and_post_process(@workspace, ["user"])[:user_id].should == @workspace.user.id.to_s
+        expect(@presenter.present_and_post_process(@workspace, ["user"])[:user_id]).to eq(@workspace.user.id.to_s)
       end
 
       it "converts non-association models into <model>_id format when they are requested" do
-        @presenter.present_and_post_process(@workspace, ["lead_user"])[:lead_user_id].should == @workspace.lead_user.id.to_s
+        expect(@presenter.present_and_post_process(@workspace, ["lead_user"])[:lead_user_id]).to eq(@workspace.lead_user.id.to_s)
       end
 
       it "handles associations provided with lambdas" do
-        @presenter.present_and_post_process(@workspace, ["lead_user_with_lambda"])[:lead_user_with_lambda_id].should == @workspace.lead_user.id.to_s
-        @presenter.present_and_post_process(@workspace, ["tasks_with_lambda"])[:tasks_with_lambda_ids].should == @workspace.tasks.map(&:id).map(&:to_s)
+        expect(@presenter.present_and_post_process(@workspace, ["lead_user_with_lambda"])[:lead_user_with_lambda_id]).to eq(@workspace.lead_user.id.to_s)
+        expect(@presenter.present_and_post_process(@workspace, ["tasks_with_lambda"])[:tasks_with_lambda_ids]).to eq(@workspace.tasks.map(&:id).map(&:to_s))
       end
 
       it "should return <association>_id fields when the given association ids exist on the model whether it is requested or not" do
-        @presenter.present_and_post_process(@workspace, ["user"])[:user_id].should == @workspace.user_id.to_s
+        expect(@presenter.present_and_post_process(@workspace, ["user"])[:user_id]).to eq(@workspace.user_id.to_s)
 
         json = @presenter.present_and_post_process(@workspace, [])
-        json.keys.should =~ [:user_id, :something_id, :id, :updated_at]
-        json[:user_id].should == @workspace.user_id.to_s
-        json[:something_id].should == @workspace.user_id.to_s
+        expect(json.keys).to match_array([:user_id, :something_id, :id, :updated_at])
+        expect(json[:user_id]).to eq(@workspace.user_id.to_s)
+        expect(json[:something_id]).to eq(@workspace.user_id.to_s)
       end
 
       it "should return null, not empty string when ids are missing" do
         @workspace.user = nil
         @workspace.tasks = []
-        @presenter.present_and_post_process(@workspace, ["lead_user_with_lambda"])[:lead_user_with_lambda_id].should == nil
-        @presenter.present_and_post_process(@workspace, ["user"])[:user_id].should == nil
-        @presenter.present_and_post_process(@workspace, ["something"])[:something_id].should == nil
-        @presenter.present_and_post_process(@workspace, ["tasks"])[:task_ids].should == []
+        expect(@presenter.present_and_post_process(@workspace, ["lead_user_with_lambda"])[:lead_user_with_lambda_id]).to eq(nil)
+        expect(@presenter.present_and_post_process(@workspace, ["user"])[:user_id]).to eq(nil)
+        expect(@presenter.present_and_post_process(@workspace, ["something"])[:something_id]).to eq(nil)
+        expect(@presenter.present_and_post_process(@workspace, ["tasks"])[:task_ids]).to eq([])
       end
 
       context "when the model has an <association>_id method but no column" do
@@ -246,7 +246,7 @@ describe Brainstem::Presenter do
           def @workspace.synthetic_id
             raise "this explodes because it's not an association"
           end
-          @presenter.present_and_post_process(@workspace, []).should_not have_key(:synthetic_id)
+          expect(@presenter.present_and_post_process(@workspace, [])).not_to have_key(:synthetic_id)
         end
       end
     end

--- a/spec/brainstem_spec.rb
+++ b/spec/brainstem_spec.rb
@@ -4,22 +4,22 @@ describe Brainstem do
   describe "default_namespace attribute" do
     it "can be set and read" do
       Brainstem.default_namespace = "something"
-      Brainstem.default_namespace.should eq("something")
+      expect(Brainstem.default_namespace).to eq("something")
     end
 
     it "returns 'none' if unset" do
-      Brainstem.default_namespace.should eq("none")
+      expect(Brainstem.default_namespace).to eq("none")
     end
   end
 
   describe "presenter collection method" do
     it "returns an instance of PresenterCollection" do
-      Brainstem.presenter_collection.should be_a(Brainstem::PresenterCollection)
+      expect(Brainstem.presenter_collection).to be_a(Brainstem::PresenterCollection)
     end
 
     it "accepts a namespace" do
-      Brainstem.presenter_collection("v1").should be_a(Brainstem::PresenterCollection)
-      Brainstem.presenter_collection("v1").should_not eq(Brainstem.presenter_collection)
+      expect(Brainstem.presenter_collection("v1")).to be_a(Brainstem::PresenterCollection)
+      expect(Brainstem.presenter_collection("v1")).not_to eq(Brainstem.presenter_collection)
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.1 with the following command:
    transpec
- 210 conversions
  from: obj.should
    to: expect(obj).to
- 108 conversions
  from: == expected
    to: eq(expected)
- 13 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 12 conversions
  from: =~ [1, 2]
    to: match_array([1, 2])
- 5 conversions
  from: lambda { }.should
    to: expect { }.to
- 4 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 4 conversions
  from: > expected
    to: be > expected
- 3 conversions
  from: be_true
    to: be_truthy
- 2 conversions
  from: be_false
    to: be_falsey
- 2 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
- 1 conversion
  from: <= expected
    to: be <= expected

For more details: https://github.com/yujinakayama/transpec#supported-conversions
