### PR TITLE
Call `reflections` on class instead of instance

### DIFF
--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -156,7 +156,7 @@ module Brainstem
 
           if id_attr && model.class.columns_hash.has_key?(id_attr)
             struct["#{key}_id".to_sym] = to_s_except_nil(model.send(id_attr))
-            reflection = value.method_name && model.reflections[value.method_name.to_sym]
+            reflection = value.method_name && model.class.reflections[value.method_name.to_sym]
             if reflection && reflection.options[:polymorphic]
               struct["#{key.to_s.singularize}_type".to_sym] = model.send("#{value.method_name}_type")
             end

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -326,7 +326,7 @@ module Brainstem
       records.tap do |models|
         association_names_to_preload = includes_hash.values.map {|i| i.method_name }
         if models.first
-          reflections = models.first.reflections
+          reflections = models.first.class.reflections
           association_names_to_preload.reject! { |association| !reflections.has_key?(association) }
         end
         if association_names_to_preload.any?


### PR DESCRIPTION
This fixes the issue discovered while looking at pull #31. 91 out of 127 tests were failing, all with the same error: NoMethodError for 'reflections'.

[An issue with the Globalize gem](https://github.com/globalize/globalize/issues/359) led me down the right path to fix this. Essentially, the reflections module was [refactored](https://github.com/rails/rails/pull/15300) in Rails, which removed the `reflections` method from Active Model instances. The method _is_ still available on the class, so I call that method instead.

All tests are passing for me now. I've also tested this with Rails 3.2 and 4.0, and it works.
