### PR TITLE
Temporarily patch gemspec to ignore rails 4.2

### DIFF
--- a/brainstem.gemspec
+++ b/brainstem.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Brainstem::VERSION
 
-  gem.add_dependency "activerecord", ">= 3.2"
+  gem.add_dependency "activerecord", ">= 3.2", "< 4.2"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "redcarpet" # for markdown in yard


### PR DESCRIPTION
This is a temporary workaround until #39 is resolved.