### PR TITLE
Pass hash to brainstem filter options

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -233,7 +233,7 @@ module Brainstem
 
       (options[:presenter].filters || {}).each do |filter_name, filter|
         requested = options[:params][filter_name]
-        requested = requested.is_a?(Array) ? requested : (requested.present? ? requested.to_s : nil)
+        requested = (requested.is_a?(Array) || requested.is_a?(Hash)) ? requested : (requested.present? ? requested.to_s : nil)
         requested = requested == "true" ? true : (requested == "false" ? false : requested)
 
         filter_options = filter[0]

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -132,7 +132,7 @@ describe Brainstem::PresenterCollection do
 
         context "raise_on_empty is false" do
           it "should not raise an exception when the results are empty" do
-            expect { 
+            expect {
               @presenter_collection.presenting("workspaces") { Workspace.where(:id => nil) }
             }.not_to raise_error
           end
@@ -369,14 +369,25 @@ describe Brainstem::PresenterCollection do
         expect(result[:workspaces].values.find { |workspace| workspace[:title].include?("bob") }).not_to be
       end
 
-      it "ensures arguments are strings if they are not arrays" do
+      it "ensures arguments are strings if they are not arrays or hashes" do
         filter_was_run = false
         WorkspacePresenter.filter(:owned_by_bob) do |scope, string|
           filter_was_run = true
           expect(string).to be_a(String)
           scope
         end
-        @presenter_collection.presenting("workspaces", :params => { :owned_by_bob => { :wut => "is this?" } }) { Workspace.where(nil) }
+        @presenter_collection.presenting("workspaces", :params => { :owned_by_bob => Object }) { Workspace.where(nil) }
+        expect(filter_was_run).to be_truthy
+      end
+
+      it "preserves hash arguments" do
+        filter_was_run = false
+        WorkspacePresenter.filter(:owned_by_bob) do |scope, hash|
+          filter_was_run = true
+          expect(hash).to be_a(Hash)
+          scope
+        end
+        @presenter_collection.presenting("workspaces", :params => { :owned_by_bob => {:test => 'abc'} }) { Workspace.where(nil) }
         expect(filter_was_run).to be_truthy
       end
 


### PR DESCRIPTION
Allow hashes to be sent to a Brainstem filter.
