### PR TITLE
Add tooling to help build Brainstem Controllers

### DIFF
--- a/lib/brainstem/concerns/controller_param_management.rb
+++ b/lib/brainstem/concerns/controller_param_management.rb
@@ -1,0 +1,20 @@
+module Brainstem
+  module Concerns
+    module ControllerParamManagement
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :brainstem_plural_model_name, :brainstem_model_name,
+                        instance_accessor: false, instance_reader: false, instance_writer: false
+      end
+
+      def brainstem_model_name
+        self.class.brainstem_model_name.to_s.presence || controller_name.singularize
+      end
+
+      def brainstem_plural_model_name
+        self.class.brainstem_plural_model_name.to_s.presence || brainstem_model_name.pluralize
+      end
+    end
+  end
+end

--- a/lib/brainstem/controller_methods.rb
+++ b/lib/brainstem/controller_methods.rb
@@ -1,9 +1,13 @@
+require 'brainstem/concerns/controller_param_management'
+
 module Brainstem
 
   # ControllerMethods are intended to be included into controllers that will be handling requests for presented objects.
   # The present method will pass through +params+, so that any allowed and requested includes, filters, sort orders
   # will be applied to the presented data.
   module ControllerMethods
+    extend ActiveSupport::Concern
+    include Concerns::ControllerParamManagement
 
     # Return a Ruby hash that contains models requested by the user's params and allowed
     # by the +name+ presenter's configuration.

--- a/spec/brainstem/concerns/controller_param_management_spec.rb
+++ b/spec/brainstem/concerns/controller_param_management_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'brainstem/concerns/controller_param_management'
+
+describe Brainstem::Concerns::ControllerParamManagement do
+  class TasksController
+    include Brainstem::Concerns::ControllerParamManagement
+
+    def controller_name
+      'tasks'
+    end
+  end
+
+  before do
+    TasksController.brainstem_model_name = nil
+    TasksController.brainstem_plural_model_name = nil
+  end
+
+  describe '.brainstem_model_name' do
+    it 'is settable on the controller' do
+      TasksController.brainstem_model_name = 'thingy'
+      expect(TasksController.new.brainstem_model_name).to eq 'thingy'
+    end
+
+    it 'has good defaults' do
+      expect(TasksController.new.brainstem_model_name).to eq 'task'
+      expect(TasksController.new.brainstem_plural_model_name).to eq 'tasks'
+    end
+  end
+
+  describe '.brainstem_plural_model_name' do
+    it 'is infered from the singular model name' do
+      TasksController.brainstem_model_name = 'thingy'
+      expect(TasksController.new.brainstem_plural_model_name).to eq 'thingies'
+    end
+
+    it 'can be overridden' do
+      TasksController.brainstem_model_name = 'thingy'
+      TasksController.brainstem_plural_model_name = 'thingzees'
+      expect(TasksController.new.brainstem_plural_model_name).to eq 'thingzees'
+    end
+  end
+end

--- a/spec/brainstem/controller_methods_spec.rb
+++ b/spec/brainstem/controller_methods_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'spec_helpers/presenters'
 
 describe Brainstem::ControllerMethods do
-  class FakeController
+  class TasksController
     include Brainstem::ControllerMethods
 
     attr_accessor :call_results
@@ -21,7 +21,7 @@ describe Brainstem::ControllerMethods do
 
   describe "#present_object" do
     before do
-      @controller = FakeController.new
+      @controller = TasksController.new
     end
 
     describe "calling #present with sensible params" do


### PR DESCRIPTION
* Infer the param model name from the controller_name, with optional overload