### PR TITLE
Add the option for filters to be passed the params

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -227,15 +227,15 @@ module Brainstem
     def run_filters(scope, options)
       extracted_filters = extract_filters(options)
       extracted_filters.each do |filter_name, filter_opts|
-        args = filter_opts[:args]
+        arg = filter_opts[:arg]
         include_params = filter_opts[:include_params]
-        next if args.nil?
+        next if arg.nil?
         filter_lambda = options[:presenter].filters[filter_name][1]
 
         if filter_lambda
-          scope = include_params ? filter_lambda.call(scope, args, extracted_filters) : filter_lambda.call(scope, args)
+          scope = include_params ? filter_lambda.call(scope, arg, extracted_filters) : filter_lambda.call(scope, arg)
         else
-          scope = include_params ? scope.send(filter_name, args, extracted_filters) : scope.send(filter_name, args)
+          scope = include_params ? scope.send(filter_name, arg, extracted_filters) : scope.send(filter_name, arg)
         end
       end
 
@@ -252,8 +252,8 @@ module Brainstem
         requested = requested == "true" ? true : (requested == "false" ? false : requested)
 
         filter_options = filter[0]
-        args = run_defaults && requested.nil? ? filter_options[:default] : requested
-        filters_hash[filter_name] = { args: args, include_params: filter_options[:include_params] }
+        arg = run_defaults && requested.nil? ? filter_options[:default] : requested
+        filters_hash[filter_name] = { arg: arg, include_params: filter_options[:include_params] }
       end
 
       filters_hash
@@ -280,10 +280,10 @@ module Brainstem
 
       extracted_filters = extract_filters(options)
       extracted_filters.each do |key, val|
-        if val[:args].nil?
+        if val[:arg].nil?
           extracted_filters.delete(key)
         else
-          extracted_filters[key] = val[:args]
+          extracted_filters[key] = val[:arg]
         end
       end
 

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -279,15 +279,11 @@ module Brainstem
       end
 
       extracted_filters = extract_filters(options)
-      extracted_filters.each do |key, val|
-        if val[:arg].nil?
-          extracted_filters.delete(key)
-        else
-          extracted_filters[key] = val[:arg]
-        end
+      extracted_filters_for_search = extracted_filters.each.with_object({}) do |(key, val), hash|
+        hash[key] = val[:arg] unless val[:arg].nil?
       end
 
-      search_options.reverse_merge!(extracted_filters)
+      search_options.reverse_merge!(extracted_filters_for_search)
 
       result_ids, count = options[:presenter].search_block.call(options[:params][:search], search_options)
       if result_ids

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -502,6 +502,19 @@ describe Brainstem::PresenterCollection do
           expect(result[:workspaces].keys).to eq(%w[2 4])
         end
       end
+
+      context "with include_params" do
+        it "passes the params into the filter block" do
+          WorkspacePresenter.filter :filter_with_param, :include_params => true do |scope, option, params|
+            expect(params["owned_by"]).to be_present
+            expect(params["title"]).to be_present
+            expect(params["filter_with_param"]).to be_present
+            scope
+          end
+
+          @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "1" }) { Workspace.where(nil) }
+        end
+      end
     end
 
     describe "search" do


### PR DESCRIPTION
@cantino here's the change we discussed. The use case for this is if you have a filter that you want to conditionally change depending on other filters. The use case might look like this:

```ruby
filter :cool_filter, :include_params => true do |scope, opts, params|
  if params[:other_filter].present?
    scope
  else
    scope.cool_scope
  end
end
```