### PR TITLE
Have params hash be key => val instead of key => { arg: val }

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -228,7 +228,7 @@ module Brainstem
       extracted_filters = extract_filters(options)
 
       params = extracted_filters.each.with_object({}) do |(key, val), hash|
-        hash[key] = val[:arg]
+        hash[key] = val[:arg] unless val[:arg].nil?
       end
 
       extracted_filters.each do |filter_name, filter_opts|

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -226,6 +226,11 @@ module Brainstem
 
     def run_filters(scope, options)
       extracted_filters = extract_filters(options)
+
+      params = extracted_filters.each.with_object({}) do |(key, val), hash|
+        hash[key] = val[:arg]
+      end
+
       extracted_filters.each do |filter_name, filter_opts|
         arg = filter_opts[:arg]
         include_params = filter_opts[:include_params]
@@ -233,9 +238,9 @@ module Brainstem
         filter_lambda = options[:presenter].filters[filter_name][1]
 
         if filter_lambda
-          scope = include_params ? filter_lambda.call(scope, arg, extracted_filters) : filter_lambda.call(scope, arg)
+          scope = include_params ? filter_lambda.call(scope, arg, params) : filter_lambda.call(scope, arg)
         else
-          scope = include_params ? scope.send(filter_name, arg, extracted_filters) : scope.send(filter_name, arg)
+          scope = include_params ? scope.send(filter_name, arg, params) : scope.send(filter_name, arg)
         end
       end
 

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -505,14 +505,16 @@ describe Brainstem::PresenterCollection do
 
       context "with include_params" do
         it "passes the params into the filter block" do
+          WorkspacePresenter.filter(:other_filter) { |scope, opt| scope }
           WorkspacePresenter.filter :filter_with_param, :include_params => true do |scope, option, params|
             expect(params["owned_by"]).to be_nil
             expect(params["title"]).to be_nil
             expect(params["filter_with_param"]).to eq("arg")
+            expect(params["other_filter"]).to eq("another_arg")
             scope
           end
 
-          @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "arg" }) { Workspace.where(nil) }
+          @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "arg", :other_filter => 'another_arg' }) { Workspace.where(nil) }
         end
       end
     end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -506,13 +506,13 @@ describe Brainstem::PresenterCollection do
       context "with include_params" do
         it "passes the params into the filter block" do
           WorkspacePresenter.filter :filter_with_param, :include_params => true do |scope, option, params|
-            expect(params["owned_by"]).to be_present
-            expect(params["title"]).to be_present
-            expect(params["filter_with_param"]).to be_present
+            expect(params["owned_by"]).to be_nil
+            expect(params["title"]).to be_nil
+            expect(params["filter_with_param"]).to eq("arg")
             scope
           end
 
-          @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "1" }) { Workspace.where(nil) }
+          @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "arg" }) { Workspace.where(nil) }
         end
       end
     end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -507,8 +507,6 @@ describe Brainstem::PresenterCollection do
         it "passes the params into the filter block" do
           WorkspacePresenter.filter(:other_filter) { |scope, opt| scope }
           WorkspacePresenter.filter :filter_with_param, :include_params => true do |scope, option, params|
-            expect(params["owned_by"]).to be_nil
-            expect(params["title"]).to be_nil
             expect(params["filter_with_param"]).to eq("arg")
             expect(params["other_filter"]).to eq("another_arg")
             scope


### PR DESCRIPTION
@cantino this updates the filters params hash to be `key => val` instead of `key => { arg: val }`.