### PR TITLE
Compact search results if a value isn't found with the scope.  

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -309,7 +309,7 @@ module Brainstem
         ordered_records[ids_to_position[record.id]] = record
       end
 
-      ordered_records
+      ordered_records.compact
     end
 
     def handle_ordering(scope, options)

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -555,7 +555,6 @@ describe Brainstem::PresenterCollection do
 
           it "keeps the records in the order returned by search" do
             result = @presenter_collection.presenting("workspaces", :params => { :search => "blah" }) { Workspace.unscoped }
-
           end
 
           it "throws a SearchUnavailableError if the search block returns false" do
@@ -566,6 +565,20 @@ describe Brainstem::PresenterCollection do
             expect {
               @presenter_collection.presenting("workspaces", :params => { :search => "blah" }) { Workspace.unscoped }
             }.to raise_error(Brainstem::SearchUnavailableError)
+          end
+
+          context "when the search results give ids that cannot be found" do
+            before  do
+              WorkspacePresenter.search do |string|
+                [[5, 8, 3], 3]
+              end
+            end
+
+            it "will generate a compacted list, without nil or 0 values" do
+              result = @presenter_collection.presenting("workspaces", :params => { :search => "blah" }) { Workspace.order("id asc") }
+              expect(result[:workspaces].keys).to eq(%w[5 3])
+              expect(result[:count]).to eq(3)
+            end
           end
 
           describe "passing options to the search block" do


### PR DESCRIPTION
It is possible that a search result could have id's that are not found in the scope. We are compacting the search results to protect against
that here.


/cc @cantino @jhmoore 