### PR TITLE
Add params to filters

### DIFF
--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -147,13 +147,17 @@ module Brainstem
     def apply_filters_to_scope(scope, user_params, options)
       helper_instance = fresh_helper_instance
 
-      extract_filters(user_params, options).each do |filter_name, filter_arg|
+      requested_filters = extract_filters(user_params, options)
+      requested_filters.each do |filter_name, filter_arg|
         filter_lambda = configuration[:filters][filter_name][1]
 
+        args_for_filter_lambda = [filter_arg]
+        args_for_filter_lambda << requested_filters if configuration[:filters][filter_name][0][:include_params]
+
         if filter_lambda
-          scope = helper_instance.instance_exec(scope, filter_arg, &filter_lambda)
+          scope = helper_instance.instance_exec(scope, *args_for_filter_lambda, &filter_lambda)
         else
-          scope = scope.send(filter_name, filter_arg)
+          scope = scope.send(filter_name, *args_for_filter_lambda)
         end
       end
 

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -509,6 +509,25 @@ describe Brainstem::PresenterCollection do
           expect(result['workspaces'].keys).to eq(%w[2 4])
         end
       end
+
+      context "with include_params" do
+        it "passes the params into the filter block" do
+          WorkspacePresenter.filter(:other_filter) { |scope, opt| scope }
+          WorkspacePresenter.filter(:other_filter_with_default, default: true) { |scope, opt| scope }
+
+          provided_params = nil
+          WorkspacePresenter.filter :filter_with_param, :include_params => true do |scope, option, params|
+            provided_params = params
+            scope
+          end
+
+          @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "arg", :other_filter => 'another_arg' }) { Workspace.where(nil) }
+
+          expect(provided_params["filter_with_param"]).to eq("arg")
+          expect(provided_params["other_filter"]).to eq("another_arg")
+          expect(provided_params["other_filter_with_default"]).to eq(true)
+        end
+      end
     end
 
     describe "search" do

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -513,6 +513,7 @@ describe Brainstem::PresenterCollection do
       context "with include_params" do
         it "passes the params into the filter block" do
           WorkspacePresenter.filter(:other_filter) { |scope, opt| scope }
+          WorkspacePresenter.filter(:unused_filter) { |scope, opt| scope }
           WorkspacePresenter.filter(:other_filter_with_default, default: true) { |scope, opt| scope }
 
           provided_params = nil
@@ -523,9 +524,7 @@ describe Brainstem::PresenterCollection do
 
           @presenter_collection.presenting("workspaces", :params => { :filter_with_param => "arg", :other_filter => 'another_arg' }) { Workspace.where(nil) }
 
-          expect(provided_params["filter_with_param"]).to eq("arg")
-          expect(provided_params["other_filter"]).to eq("another_arg")
-          expect(provided_params["other_filter_with_default"]).to eq(true)
+          expect(provided_params).to eq({ "filter_with_param" => "arg", "other_filter" => "another_arg", "other_filter_with_default" => true })
         end
       end
     end


### PR DESCRIPTION
@naiyt, how does this look?  In forward-porting your changes to Cerebellum, it seemed like we could simplify by not changing `extract_filters` at all, and instead looking into the configuration when calling a filter to see if it has requested `include_params`.  Do you see any differences between this and master, around how it handles `nil` or default filters, for example?  It seems like it'd be the same.