### PR TITLE
Allow configuration of links independent from filenames

### DIFF
--- a/lib/brainstem/api_docs.rb
+++ b/lib/brainstem/api_docs.rb
@@ -40,6 +40,36 @@ module Brainstem
 
 
     #
+    # Defines the naming pattern for the relative link to each controller documentation file.
+    #
+    # The following tokens will be substituted:
+    #
+    # - {{name}} : the underscored name of the controller without 'controller'
+    # - {{extension} : the specified file extension
+    #
+    # @see #output_extension
+    #
+    config_accessor(:controller_filename_link_pattern) do
+      controller_filename_pattern
+    end
+
+
+    #
+    # Defines the naming pattern for the relative link to each presenter documentation file.
+    #
+    # The following tokens will be substituted:
+    #
+    # - {{name}} : the demodulized underscored name of the presenter
+    # - {{extension} : the specified file extension
+    #
+    # @see #output_extension
+    #
+    config_accessor(:presenter_filename_link_pattern) do
+      presenter_filename_pattern
+    end
+
+
+    #
     # Defines the extension that should be used for output files.
     #
     # Excludes the '.'.

--- a/lib/brainstem/api_docs/controller.rb
+++ b/lib/brainstem/api_docs/controller.rb
@@ -20,11 +20,18 @@ module Brainstem
                     :name,
                     :endpoints
 
+
+      attr_writer   :filename_pattern,
+                    :filename_link_pattern
+
+
       def valid_options
         super | [
           :const,
           :name,
-          :formatters
+          :formatters,
+          :filename_pattern,
+          :filename_link_pattern
         ]
       end
 
@@ -44,6 +51,13 @@ module Brainstem
       end
 
 
+      def suggested_filename_link(format)
+        filename_link_pattern
+          .gsub('{{name}}', name.to_s)
+          .gsub('{{extension}}', extension)
+      end
+
+
       def extension
         @extension ||= Brainstem::ApiDocs.output_extension
       end
@@ -51,6 +65,11 @@ module Brainstem
 
       def filename_pattern
         @filename_pattern ||= Brainstem::ApiDocs.controller_filename_pattern
+      end
+
+
+      def filename_link_pattern
+        @filename_link_pattern ||= Brainstem::ApiDocs.controller_filename_link_pattern
       end
 
 

--- a/lib/brainstem/api_docs/endpoint.rb
+++ b/lib/brainstem/api_docs/endpoint.rb
@@ -238,8 +238,8 @@ module Brainstem
 
       def relative_presenter_path_from_controller(format)
         if presenter && controller
-          controller_path = Pathname.new(File.dirname(controller.suggested_filename(format)))
-          presenter_path  = Pathname.new(presenter.suggested_filename(format))
+          controller_path = Pathname.new(File.dirname(controller.suggested_filename_link(format)))
+          presenter_path  = Pathname.new(presenter.suggested_filename_link(format))
 
           presenter_path.relative_path_from(controller_path).to_s
         end

--- a/lib/brainstem/api_docs/presenter.rb
+++ b/lib/brainstem/api_docs/presenter.rb
@@ -17,14 +17,16 @@ module Brainstem
         super | [
           :const,
           :presents,
-          :filename_pattern
+          :filename_pattern,
+          :filename_link_pattern
         ]
       end
 
       attr_accessor :const,
                     :presents
 
-      attr_writer   :filename_pattern
+      attr_writer   :filename_pattern,
+                    :filename_link_pattern
 
 
       def initialize(options = {})
@@ -40,6 +42,13 @@ module Brainstem
       end
 
 
+      def suggested_filename_link(format)
+        filename_link_pattern
+          .gsub('{{name}}', presents.to_s)
+          .gsub('{{extension}}', extension)
+      end
+
+
       def extension
         @extension ||= Brainstem::ApiDocs.output_extension
       end
@@ -47,6 +56,11 @@ module Brainstem
 
       def filename_pattern
         @filename_pattern ||= Brainstem::ApiDocs.presenter_filename_pattern
+      end
+
+
+      def filename_link_pattern
+        @filename_link_pattern ||= Brainstem::ApiDocs.presenter_filename_link_pattern
       end
 
 

--- a/spec/brainstem/api_docs/controller_spec.rb
+++ b/spec/brainstem/api_docs/controller_spec.rb
@@ -145,6 +145,22 @@ module Brainstem
         end
       end
 
+
+      describe "#suggested_filename_link" do
+        it "gsubs filename and extension" do
+
+          instance = described_class.new(
+            filename_link_pattern: "controllers/{{name}}_controller.{{extension}}.foo",
+            name: 'abc'
+          )
+
+          stub(instance).extension { "xyz" }
+
+          expect(instance.suggested_filename_link(:xyz)).to eq "controllers/abc_controller.xyz.foo"
+        end
+      end
+
+
       it_behaves_like "formattable"
     end
   end

--- a/spec/brainstem/api_docs/endpoint_spec.rb
+++ b/spec/brainstem/api_docs/endpoint_spec.rb
@@ -208,24 +208,23 @@ module Brainstem
       describe "#relative_presenter_path_from_controller" do
         let(:presenter) {
           mock!
-            .suggested_filename(:markdown)
-            .returns("models/sprocket_widget.markdown")
+            .suggested_filename_link(:markdown)
+            .returns("objects/sprocket_widget")
             .subject
         }
 
         let(:controller) {
           mock!
-            .suggested_filename(:markdown)
-            .returns("controllers/api/v1/sprocket_widgets_controller.markdown")
+            .suggested_filename_link(:markdown)
+            .returns("controllers/api/v1/sprocket_widgets_controller")
             .subject
         }
 
         let(:options) { { presenter: presenter, controller: controller } }
 
-
         it "returns a relative path" do
           expect(subject.relative_presenter_path_from_controller(:markdown)).to \
-            eq "../../../models/sprocket_widget.markdown"
+            eq "../../../objects/sprocket_widget"
         end
       end
 

--- a/spec/brainstem/api_docs/presenter_spec.rb
+++ b/spec/brainstem/api_docs/presenter_spec.rb
@@ -264,6 +264,21 @@ module Brainstem
       end
 
 
+      describe "#suggested_filename_link" do
+        it "gsubs name and extension" do
+
+          instance = described_class.new(
+            filename_link_pattern: "presenters/{{name}}.{{extension}}.foo",
+            presents: 'abc'
+          )
+
+          stub(instance).extension { "xyz" }
+
+          expect(instance.suggested_filename_link(:xyz)).to eq "presenters/abc.xyz.foo"
+        end
+      end
+
+
       it_behaves_like "formattable"
     end
   end

--- a/spec/brainstem/api_docs_spec.rb
+++ b/spec/brainstem/api_docs_spec.rb
@@ -17,17 +17,37 @@ module Brainstem
       %w(
         controller_filename_pattern
         presenter_filename_pattern
+        controller_filename_link_pattern
+        presenter_filename_link_pattern
         write_path
         output_extension
         base_presenter_class
         base_controller_class
       ).each do |meth|
         describe meth do
+          before do
+            @original = Brainstem::ApiDocs.public_send(meth)
+          end
+
+          after do
+            Brainstem::ApiDocs.public_send("#{meth}=", @original)
+          end
+
           it "can be set and read" do
             Brainstem::ApiDocs.public_send("#{meth}=", lorem)
             expect(Brainstem::ApiDocs.public_send(meth)).to eq lorem
           end
         end
+      end
+    end
+
+    describe "filename link patterns" do
+      it 'defaults to the filename pattern' do
+        expect(Brainstem::ApiDocs.public_send("controller_filename_link_pattern")).
+          to eq(Brainstem::ApiDocs.public_send("controller_filename_pattern"))
+
+        expect(Brainstem::ApiDocs.public_send("presenter_filename_link_pattern")).
+          to eq(Brainstem::ApiDocs.public_send("presenter_filename_pattern"))
       end
     end
 


### PR DESCRIPTION
@robyurkowski, we wanted to be able to have the generated links skip the extension (since we put them in individual directories with middleman for pretty routes), but still want extensions on the actual filenames.  How's this look?