### PR TITLE
Remove warnings when running specs

### DIFF
--- a/spec/brainstem/api_docs/formatters/abstract_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/abstract_formatter_spec.rb
@@ -8,14 +8,11 @@ module Brainstem
         subject { AbstractFormatter.new }
 
         describe ".call" do
-          before do
-            any_instance_of(described_class) do |instance|
-              mock.proxy(instance).initialize(1, 2, {})
-              mock(instance).call
-            end
-          end
-
           it "instantiates a new instance and calls it, passing the instance all args" do
+            mock(described_class).new(1, 2, {}) do |instance|
+              mock(Object.new).call
+            end
+
             described_class.call(1, 2, {})
           end
         end

--- a/spec/dummy/rails.rb
+++ b/spec/dummy/rails.rb
@@ -1,9 +1,11 @@
 # This is a dummy file which is used in the Introspector specs to simulate a
 # loaded rails app.
-FakeRailsApplication      = Struct.new(:eager_load!, :routes)
-FakeRailsRoutesObject     = Struct.new(:routes)
-FakeRailsRoutePathObject  = Struct.new(:spec)
-FakeRailsRoute            = Struct.new(:name, :path, :defaults, :constraints)
+silence_warnings do
+  FakeRailsApplication      = Struct.new(:eager_load!, :routes)
+  FakeRailsRoutesObject     = Struct.new(:routes)
+  FakeRailsRoutePathObject  = Struct.new(:spec)
+  FakeRailsRoute            = Struct.new(:name, :path, :defaults, :constraints)
+end
 
 
 class Rails


### PR DESCRIPTION
@robyurkowski, this fixes two different warnings present in the spec output.

```
*.*........................................*...........**....................*****..../Users/andrew/.rvm/gems/ruby-2.2.3@brainstem/gems/rr-1.1.2/lib/rr/injections/double_injection.rb:168: warning: removing `initialize' may cause serious problems
...................................................................................................................../Users/andrew/workspace/brainstem/spec/dummy/rails.rb:3: warning: already initialized constant FakeRailsApplication
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:3: warning: previous definition of FakeRailsApplication was here
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:4: warning: already initialized constant FakeRailsRoutesObject
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:4: warning: previous definition of FakeRailsRoutesObject was here
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:5: warning: already initialized constant FakeRailsRoutePathObject
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:5: warning: previous definition of FakeRailsRoutePathObject was here
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:6: warning: already initialized constant FakeRailsRoute
/Users/andrew/workspace/brainstem/spec/dummy/rails.rb:6: warning: previous definition of FakeRailsRoute was here
......................................*............**.......................*.............................................................................................................................................................................................................................
```