### PR TITLE
Validate that the brainstem_key is required on presenters that accept multiple classes

### DIFF
--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -18,7 +18,7 @@ module Brainstem
         if klasses.any? { |klass| klass.is_a?(String) || klass.is_a?(Symbol) }
           raise "Brainstem Presenter#presents now expects a Class instead of a class name"
         end
-        @presents += klasses
+        @presents.concat(klasses).uniq!
         Brainstem.add_presenter_class(self, namespace, *klasses)
       end
       @presents

--- a/lib/brainstem/presenter_validator.rb
+++ b/lib/brainstem/presenter_validator.rb
@@ -17,6 +17,7 @@ module Brainstem
     validate :conditionals_exist
     validate :default_sort_is_used
     validate :default_sort_matches_sort_order
+    validate :brainstem_key_is_provided
 
     def preloads_exist
       presenter_class.configuration[:preloads].each do |preload|
@@ -83,6 +84,12 @@ module Brainstem
         if !presenter_class.configuration[:sort_orders][default_sort_order]
           errors.add(:default_sort_order, "The declared default_sort_order ('#{default_sort_order}') does not match an existing sort_order")
         end
+      end
+    end
+
+    def brainstem_key_is_provided
+      if !presenter_class.configuration[:brainstem_key] && presenter_class.presents.length > 1
+        errors.add(:brainstem_key, "a brainstem_key must be provided when multiple classes are presented.")
       end
     end
   end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -507,7 +507,6 @@ describe Brainstem::PresenterCollection do
 
         before do
           WorkspacePresenter.filter(:owned_by, :default => bob.id)
-          WorkspacePresenter.presents Workspace
         end
 
         it "calls the named scope with default arguments" do

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -47,6 +47,11 @@ describe Brainstem::Presenter do
         expect(presenter_class.presents).to eq([String, Array])
       end
 
+      it 'removes duplicates when called more then once' do
+        expect(presenter_class.presents(Array)).to eq([Array])
+        expect(presenter_class.presents(Array, Array)).to eq([Array])
+      end
+
       it 'should not be inherited' do
         presenter_class.presents(String)
         expect(presenter_class.presents).to eq [String]

--- a/spec/brainstem/presenter_validator_spec.rb
+++ b/spec/brainstem/presenter_validator_spec.rb
@@ -193,6 +193,14 @@ describe Brainstem::PresenterValidator do
     end
   end
 
+  describe 'validating presence of brainstem_key' do
+    it 'requires a brainstem_key to be defined when more than one object is being presented' do
+      presenter_class.presents Task
+      expect(validator).not_to be_valid
+      expect(validator.errors[:brainstem_key]).to eq ["a brainstem_key must be provided when multiple classes are presented."]
+    end
+  end
+
   specify 'all spec presenters should be valid' do
     Brainstem.presenter_collection.presenters.each do |name, klass|
       expect(Brainstem::PresenterValidator.new(klass)).to be_valid

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -110,6 +110,8 @@ end
 class AttachmentPresenter < Brainstem::Presenter
   presents Attachments::TaskAttachment, Attachments::PostAttachment
 
+  brainstem_key :attachments
+
   fields do
     field :filename, :string
   end
@@ -118,5 +120,3 @@ class AttachmentPresenter < Brainstem::Presenter
     association :subject, :polymorphic
   end
 end
-
-# TODO: inheritance of presenters


### PR DESCRIPTION
@robyurkowski, this helps get around the issue with many possible `brainstem_key`s.