### PR TITLE
Generate a lookup for complicated fields and associations available to dynamic lambdas

### DIFF
--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -18,8 +18,18 @@ module Brainstem
         end
       end
 
-      def run_on(model, helper_instance = Object.new)
-        options[:dynamic] ? helper_instance.instance_exec(model, &options[:dynamic]) : model.send(method_name)
+      def run_on(model, lookup = {}, helper_instance = Object.new)
+        proc = options[:dynamic]
+
+        if proc
+          if proc.arity > 1
+            helper_instance.instance_exec(model, lookup, &proc)
+          else
+            helper_instance.instance_exec(model, &proc)
+          end
+        else
+          model.send(method_name)
+        end
       end
 
       def polymorphic?

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -31,10 +31,13 @@ module Brainstem
         options[:optional]
       end
 
-      def run_on(model, helper_instance = Object.new)
+      def run_on(model, lookup = {}, helper_instance = Object.new)
         if options[:dynamic]
           proc = options[:dynamic]
-          if proc.arity > 0
+
+          if proc.arity > 1
+            helper_instance.instance_exec(model, lookup, &proc)
+          elsif proc.arity > 0
             helper_instance.instance_exec(model, &proc)
           else
             helper_instance.instance_exec(&proc)

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -78,7 +78,8 @@ module Brainstem
         associations:                 configuration[:associations],
         reflections:                  reflections_for_model(models.first),
         association_objects_by_name:  association_objects_by_name,
-        optional_fields:              options[:optional_fields] || []
+        optional_fields:              options[:optional_fields] || [],
+        lookup:                       custom_lookup(models, configuration[:fields].keys)
       }
 
       sanitized_association_names = association_objects_by_name.values.map(&:method_name)
@@ -122,7 +123,11 @@ module Brainstem
     end
 
     # Subclasses can define this if they wish. This method will be called by {#group_present}.
-    def custom_preload(models, requested_associations = [])
+    def custom_preload(models, requested_associations = [], fields = [])
+    end
+
+    # Subclasses can define this if they wish.
+    def custom_lookup(models, field_keys)
     end
 
     # Given user params, build a hash of validated filter names to their unsanitized arguments.
@@ -249,7 +254,7 @@ module Brainstem
         case field
           when DSL::Field
             if field.conditionals_match?(model, context[:conditionals], context[:helper_instance], context[:conditional_cache]) && field.optioned?(context[:optional_fields])
-              result[name] = field.run_on(model, context[:helper_instance])
+              result[name] = field.run_on(model, context[:lookup], context[:helper_instance])
             end
           when DSL::Configuration
             result[name] ||= {}
@@ -271,7 +276,7 @@ module Brainstem
         # If this association has been explictly requested, execute the association here.  Additionally, store
         # the loaded models in the :load_associations_into hash for later use.
         if context[:association_objects_by_name][external_name]
-          associated_model_or_models = association.run_on(model, context[:helper_instance])
+          associated_model_or_models = association.run_on(model, context[:lookup], context[:helper_instance])
 
           if options[:load_associations_into]
             Array(associated_model_or_models).flatten.each do |associated_model|

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -79,7 +79,7 @@ module Brainstem
         reflections:                  reflections_for_model(models.first),
         association_objects_by_name:  association_objects_by_name,
         optional_fields:              options[:optional_fields] || [],
-        lookup:                       custom_lookup(models, configuration[:fields].keys)
+        lookup:                       custom_lookup(models, configuration[:fields].keys, association_objects_by_name.keys)
       }
 
       sanitized_association_names = association_objects_by_name.values.map(&:method_name)
@@ -126,8 +126,9 @@ module Brainstem
     def custom_preload(models, requested_associations = [], fields = [])
     end
 
-    # Subclasses can define this if they wish.
-    def custom_lookup(models, field_keys)
+    # Subclasses can define this if they wish. The return result of this method will be made
+    # available as the second argument for the dyanmic lambdas of fields and assocations
+    def custom_lookup(models, requested_fields = [], requested_associations = [])
     end
 
     # Given user params, build a hash of validated filter names to their unsanitized arguments.

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -32,8 +32,9 @@ describe Brainstem::DSL::Association do
 
       it 'calls the lambda in the context of the given instance' do
         instance = Object.new
+        lookup = {}
         mock(instance).some_instance_method
-        expect(association.run_on(:anything, instance)).to eq :return_value
+        expect(association.run_on(:anything, lookup, instance)).to eq :return_value
       end
     end
   end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -28,13 +28,25 @@ describe Brainstem::DSL::Association do
     end
 
     context 'when given a dynamic lambda' do
-      let(:options) { { dynamic: lambda { |model| some_instance_method; :return_value } } }
+      context 'when the lambda takes one argument' do
+        let(:options) { { dynamic: lambda { |model| some_instance_method; :return_value } } }
 
-      it 'calls the lambda in the context of the given instance' do
-        instance = Object.new
-        lookup = {}
-        mock(instance).some_instance_method
-        expect(association.run_on(:anything, lookup, instance)).to eq :return_value
+        it 'calls the lambda in the context of the given instance' do
+          instance = Object.new
+          mock(instance).some_instance_method
+          expect(association.run_on(:anything, nil, instance)).to eq :return_value
+        end
+      end
+
+      context 'when the lambda takes two arguments' do
+        let(:options) { { dynamic: lambda { |model, lookup| some_instance_method; lookup[:key] } } }
+
+        it 'calls the lambda and returns the value of the lookup' do
+          instance = Object.new
+          lookup = { key: 'value' }
+          mock(instance).some_instance_method
+          expect(association.run_on(:anything, lookup, instance)).to eq 'value'
+        end
       end
     end
   end

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -35,13 +35,28 @@ describe Brainstem::DSL::Field do
 
   describe '#run_on' do
     context 'on :dynamic fields' do
-      let(:options) { { dynamic: lambda { some_instance_method } } }
+      context 'when the :dynamic lambda takes only the model' do
+        let(:options) { { dynamic: lambda { |model| model.some_instance_method } } }
 
-      it 'calls the :dynamic lambda in the context of the given instance' do
-        do_not_allow(model).title
-        instance = Object.new
-        mock(instance).some_instance_method
-        field.run_on(model, instance)
+        it 'calls the :dynamic lambda in the context of the given instance' do
+          do_not_allow(model).title
+          instance = Object.new
+          lookup = {}
+          mock(instance).some_instance_method
+          field.run_on(model, lookup, instance)
+        end
+      end
+
+      context 'when the :dynamic lambda takes the model and a lookup' do
+        let(:options) { { dynamic: lambda { |model, lookup| model.some_instance_method } } }
+
+        it 'calls the :dynamic lambda in the context of the given instance' do
+          do_not_allow(model).title
+          instance = Object.new
+          lookup = {}
+          mock(instance).some_instance_method
+          field.run_on(model, lookup, instance)
+        end
       end
     end
 

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -36,25 +36,24 @@ describe Brainstem::DSL::Field do
   describe '#run_on' do
     context 'on :dynamic fields' do
       context 'when the :dynamic lambda takes only the model' do
-        let(:options) { { dynamic: lambda { |model| model.some_instance_method } } }
+        let(:options) { { dynamic: lambda { |model| some_instance_method(model) } } }
 
         it 'calls the :dynamic lambda in the context of the given instance' do
           do_not_allow(model).title
           instance = Object.new
-          lookup = {}
-          mock(instance).some_instance_method
-          field.run_on(model, lookup, instance)
+          mock(instance).some_instance_method(model)
+          field.run_on(model, nil, instance)
         end
       end
 
       context 'when the :dynamic lambda takes the model and a lookup' do
-        let(:options) { { dynamic: lambda { |model, lookup| model.some_instance_method } } }
+        let(:options) { { dynamic: lambda { |model, lookup| some_instance_method(model, lookup) } } }
 
-        it 'calls the :dynamic lambda in the context of the given instance' do
+        it 'calls the :dynamic lambda in the context of the given instance with the lookup' do
           do_not_allow(model).title
           instance = Object.new
           lookup = {}
-          mock(instance).some_instance_method
+          mock(instance).some_instance_method(model, lookup)
           field.run_on(model, lookup, instance)
         end
       end


### PR DESCRIPTION
This PR will allow presenters to define `custom_lookup(models, fields)` which should return a 'lookup' hash containing the included fields as keys with their values as a hash with model ids as keys and the complicated/costly fields and/or associations as values. This will allow presenters to do complicated work for their complicated fields before presenting each individual model and then pass a reference to the values for those fields when presenting.

eg.
```
  lookup 
  => { 'some_field' => {'1': 'some value', '2' => 'another value' }, 'another_field' => {...} }
```

### Before
```
      fields do
        field :complicated_field, :string,
              dynamic: lambda { |model| model.complicated_query(current_user) } # This is an N + 1
        #...
      end
```

### After

```
      def custom_lookup(models, fields)
        lookup = {}
        
        if fields.include?(:complicated_field)
          lookup[:complicated_field] = Hash[complicated_query_for_models(models, current_user).select(:id, :value)]
        end

        lookup
      end

      fields do
        field :complicated_field, :string,
              dynamic: lambda { |model, lookup| lookup[:complicated_field][model.id] }
        #...
      end
```

TODO: Specify an option for fields / associations, eg. `use_lookup: true`, which would be equivalent to having `dynamic: lambda { |model, lookup| lookup[:complicated_field][model.id] }` so we don't have to write this same lambda for fields / associations which use the lookup in this simple case.