### PR TITLE
Add support for hash filter values. 

### DIFF
--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -132,7 +132,7 @@ module Brainstem
       apply_default_filters = options.fetch(:apply_default_filters) { true }
 
       configuration[:filters].each do |filter_name, filter|
-        user_value = sanitize_filter_value(user_params[filter_name])
+        user_value = format_filter_value(user_params[filter_name])
 
         filter_options = filter[0]
         filter_arg = apply_default_filters && user_value.nil? ? filter_options[:default] : user_value
@@ -145,18 +145,20 @@ module Brainstem
     # @api private
     # @param [Array, Hash, String, Boolean, nil] value
     #
-    # Sanitizes the given filter value.
     # @return [Array, Hash, String, Boolean, nil]
-    def sanitize_filter_value(value)
+    def format_filter_value(value)
       return value if value.is_a?(Array) || value.is_a?(Hash)
       return nil if value.blank?
 
       value = value.to_s
-      return true if value == 'true'
-
-      value == 'false' ? false : value
+      case value
+        when '1', 'true', 'TRUE' then true
+        when '0', 'false', 'FALSE' then false
+        else
+          value
+      end
     end
-    private :sanitize_filter_value
+    private :format_filter_value
 
     # Given user params, build a hash of validated filter names to their unsanitized arguments.
     def apply_filters_to_scope(scope, user_params, options)

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -152,8 +152,8 @@ module Brainstem
 
       value = value.to_s
       case value
-        when '1', 'true', 'TRUE' then true
-        when '0', 'false', 'FALSE' then false
+        when 'true', 'TRUE' then true
+        when 'false', 'FALSE' then false
         else
           value
       end

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -132,9 +132,7 @@ module Brainstem
       apply_default_filters = options.fetch(:apply_default_filters) { true }
 
       configuration[:filters].each do |filter_name, filter|
-        user_value = user_params[filter_name]
-        user_value = user_value.is_a?(Array) ? user_value : (user_value.present? ? user_value.to_s : nil)
-        user_value = user_value == "true" ? true : (user_value == "false" ? false : user_value)
+        user_value = sanitize_filter_value(user_params[filter_name])
 
         filter_options = filter[0]
         filter_arg = apply_default_filters && user_value.nil? ? filter_options[:default] : user_value
@@ -143,6 +141,22 @@ module Brainstem
 
       filters_hash
     end
+
+    # @api private
+    # @param [Array, Hash, String, Boolean, nil] value
+    #
+    # Sanitizes the given filter value.
+    # @return [Array, Hash, String, Boolean, nil]
+    def sanitize_filter_value(value)
+      return value if value.is_a?(Array) || value.is_a?(Hash)
+      return nil if value.blank?
+
+      value = value.to_s
+      return true if value == 'true'
+
+      value == 'false' ? false : value
+    end
+    private :sanitize_filter_value
 
     # Given user params, build a hash of validated filter names to their unsanitized arguments.
     def apply_filters_to_scope(scope, user_params, options)

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -610,10 +610,8 @@ describe Brainstem::Presenter do
       presenter_class.filter :owned_by
       expect(presenter.extract_filters({ 'owned_by' => 'true' })).to eq({ 'owned_by' => true })
       expect(presenter.extract_filters({ 'owned_by' => 'TRUE' })).to eq({ 'owned_by' => true })
-      expect(presenter.extract_filters({ 'owned_by' => 1 })).to eq({ 'owned_by' => true })
       expect(presenter.extract_filters({ 'owned_by' => 'false' })).to eq({ 'owned_by' => false })
       expect(presenter.extract_filters({ 'owned_by' => 'FALSE' })).to eq({ 'owned_by' => false })
-      expect(presenter.extract_filters({ 'owned_by' => 0 })).to eq({ 'owned_by' => false })
       expect(presenter.extract_filters({ 'owned_by' => 'hi' })).to eq({ 'owned_by' => 'hi' })
     end
 

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -609,7 +609,11 @@ describe Brainstem::Presenter do
     it "converts 'true' and 'false' into true and false" do
       presenter_class.filter :owned_by
       expect(presenter.extract_filters({ 'owned_by' => 'true' })).to eq({ 'owned_by' => true })
+      expect(presenter.extract_filters({ 'owned_by' => 'TRUE' })).to eq({ 'owned_by' => true })
+      expect(presenter.extract_filters({ 'owned_by' => 1 })).to eq({ 'owned_by' => true })
       expect(presenter.extract_filters({ 'owned_by' => 'false' })).to eq({ 'owned_by' => false })
+      expect(presenter.extract_filters({ 'owned_by' => 'FALSE' })).to eq({ 'owned_by' => false })
+      expect(presenter.extract_filters({ 'owned_by' => 0 })).to eq({ 'owned_by' => false })
       expect(presenter.extract_filters({ 'owned_by' => 'hi' })).to eq({ 'owned_by' => 'hi' })
     end
 

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -602,6 +602,8 @@ describe Brainstem::Presenter do
       presenter_class.filter(:bar) { |scope| scope }
       expect(presenter.extract_filters({ 'foo' => 'hi' })).to eq({})
       expect(presenter.extract_filters({ 'owned_by' => '2' })).to eq({ 'owned_by' => '2' })
+      expect(presenter.extract_filters({ 'owned_by' => [2] })).to eq({ 'owned_by' => [2] })
+      expect(presenter.extract_filters({ 'owned_by' => { :ids => [2], 2 => [1] }})).to eq({ 'owned_by' => { :ids => [2], 2 => [1] }})
     end
 
     it "converts 'true' and 'false' into true and false" do


### PR DESCRIPTION
When a hash is passed in as a filter value, it gets striingified as shown below:
```
  presenter.extract_filters({ 'owned_by' => { :ids => [2], 2 => [1] }}

  returns "{ 'owned_by' => { :ids => [2], 2 => [1] }"
```

This PR fixes the issue with passing in a hash value for a filter & returns a hash rather a stringified version of the hash