### PR TITLE
Add a lookup cache option for associations and fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ Brainstem provides a rich DSL for building presenters.  This section details the
   an optional documentation string, and a number of options. By default, fields will call a model method with the same
   name as the field's name and return the result. Use the `:via` option to call a different method, or the `:dynamic` option
   to provide a lambda that takes the model and returns the field's output value. Fields which result in N + 1 queries can be
-  optimized with a `:lookup` option, detailed in the `lookup` secontion below. Fields can be conditionally returned with the
+  optimized with a `:lookup` option, detailed in the `lookup` section below. Fields can be conditionally returned with the
   `:if` option, detailed in the `conditionals` section below.  Expensive fields can be declared as `optional: true` so that they are
    only returned when `optional_fields=field` is provided in the API request. Here are some example fields:
 
@@ -571,7 +571,9 @@ presenting and every presented model gets its assocation or value from the cache
 `lookup` lambda takes in the presented models and should generate a cache containing the models' coresponding assocations
 or values. Brainstem expects the return result of the `lookup` to be a Hash where the keys are the presented models' ids
 and the values are those models' associations or values. Use the `lookup` when you would like to preload but cannot
-e.g. if your association references `current_user`.
+e.g. if your association references `current_user`. If the `lookup` opition is defined, the `dynamic` option is defined and
+one model is being presented, then the `dynamic` will be used. If multiple models are being presented and both options are defined,
+the `lookup` will be used.
 
   ```ruby
   associations do

--- a/README.md
+++ b/README.md
@@ -514,7 +514,8 @@ Brainstem provides a rich DSL for building presenters.  This section details the
   Fields have a name, which is what they will be called in the returned JSON, a type which is used for API documentation,
   an optional documentation string, and a number of options. By default, fields will call a model method with the same
   name as the field's name and return the result. Use the `:via` option to call a different method, or the `:dynamic` option
-  to provide a lambda that takes the model and returns the field's output value. Fields can be conditionally returned with the
+  to provide a lambda that takes the model and returns the field's output value. Fields which result in N + 1 queries can be
+  optimized with a `:lookup` option, detailed in the `lookup` secontion below. Fields can be conditionally returned with the
   `:if` option, detailed in the `conditionals` section below.  Expensive fields can be declared as `optional: true` so that they are
    only returned when `optional_fields=field` is provided in the API request. Here are some example fields:
 
@@ -540,6 +541,7 @@ Brainstem provides a rich DSL for building presenters.  This section details the
   class, an optional documentation string, and some options. By default, associations will call the association or
   method on the model with their name. Like fields, you can use `:via` to call a different method or association and
   `:dynamic` to provide a lambda that takes the model and returns a model, array of models, or relation of models.
+  Associations which result in N + 1 queries can be optimized with a `:lookup` option, detailed in the `lookup` secontion below.
 
   If you have an association that tends to be large and expensive to return, you can annotate it with the
   `restrict_to_only: true` option and it will only be returned when the `only` URL param is provided and contains a
@@ -561,6 +563,42 @@ Brainstem provides a rich DSL for building presenters.  This section details the
     association :previous_location, Location, "the Widget's previous location",
                 dynamic: lambda { |widget| widget.previous_locations.first }
     association :associated_objects, :polymorphic, "a mixture of objects related to this Widget"
+  end
+  ```
+  
+* `lookup` - Use this option to avoid N + 1 queries for Fields and Associations. The `lookup` lambda runs once when
+presenting and every presented model gets its assocation or value from the cache the `lookup` lambda generates. The
+`lookup` lambda takes in the presented models and should generate a cache containing the models' coresponding assocations
+or values. Brainstem expects the return result of the `lookup` to be a Hash where the keys are the presented models' ids
+and the values are those models' associations or values. Use the `lookup` when you would like to preload but cannot
+e.g. if your association references `current_user`.
+
+  ```ruby
+  associations do
+    association :current_user_groups, Group, "the Groups for the current user",
+                lookup: lambda { |models| 
+                  Group.where(subject_id: models.map(&:id)
+                    .where(user_id: current_user.id)
+                    .group_by { |group| group.subject_id } 
+                }
+  end
+	```
+* `lookup_fetch` - Use this option for Fields and Associations if you would like to override how a model should retrieve
+ its value or assocation from the cache returned by the `lookup` cache. The `lookup_fetch` lambda takes in the return
+ result from the `lookup` lambda and the presented `model`. It should return the `model`'s assocation or value. If
+ `lookup_fetch` is not defined, Brainstem will run the default. The example `lookup_fetch` below is equivalent to the default.
+
+  ```ruby
+  fields do
+    field :current_user_post_count, Post, "the number of Posts the current_user has made for this model",
+                lookup: lambda { |models| 
+                  lookup = Post.where(subject_id: models.map(&:id)
+                    .where(user_id: current_user.id)
+                    .group_by { |post| post.subject_id } 
+                  
+                  lookup
+                },
+                lookup_fetch { |lookup, model| lookup[model.id] }
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -571,36 +571,37 @@ presenting and every presented model gets its assocation or value from the cache
 `lookup` lambda takes in the presented models and should generate a cache containing the models' coresponding assocations
 or values. Brainstem expects the return result of the `lookup` to be a Hash where the keys are the presented models' ids
 and the values are those models' associations or values. Use the `lookup` when you would like to preload but cannot
-e.g. if your association references `current_user`. If the `lookup` opition is defined, the `dynamic` option is defined and
+e.g. if your association references `current_user`. If the `lookup` option is defined, the `dynamic` option is defined, and
 one model is being presented, then the `dynamic` will be used. If multiple models are being presented and both options are defined,
 the `lookup` will be used.
 
   ```ruby
   associations do
     association :current_user_groups, Group, "the Groups for the current user",
-                lookup: lambda { |models| 
-                  Group.where(subject_id: models.map(&:id)
-                    .where(user_id: current_user.id)
-                    .group_by { |group| group.subject_id } 
-                }
+      lookup: lambda { |models|
+        Group.where(subject_id: models.map(&:id)
+          .where(user_id: current_user.id)
+          .group_by { |group| group.subject_id }
+      }
   end
-	```
+  ```
+
 * `lookup_fetch` - Use this option for Fields and Associations if you would like to override how a model should retrieve
- its value or assocation from the cache returned by the `lookup` cache. The `lookup_fetch` lambda takes in the return
- result from the `lookup` lambda and the presented `model`. It should return the `model`'s assocation or value. If
+ its value or assocation returned by the `lookup` cache. The `lookup_fetch` lambda takes in the presented model and the result
+ from the `lookup` lambda. It should return the association or value from the `lookup` cache for that `model`. If
  `lookup_fetch` is not defined, Brainstem will run the default. The example `lookup_fetch` below is equivalent to the default.
 
   ```ruby
   fields do
-    field :current_user_post_count, Post, "the number of Posts the current_user has made for this model",
-                lookup: lambda { |models| 
-                  lookup = Post.where(subject_id: models.map(&:id)
-                    .where(user_id: current_user.id)
-                    .group_by { |post| post.subject_id } 
-                  
-                  lookup
-                },
-                lookup_fetch { |lookup, model| lookup[model.id] }
+    field :current_user_post_count, Post, "count of Posts the current_user has for this model",
+      lookup: lambda { |models| 
+        lookup = Post.where(subject_id: models.map(&:id)
+          .where(user_id: current_user.id)
+          .group_by { |post| post.subject_id } 
+		  
+        lookup
+       },
+       lookup_fetch: lambda { |lookup, model| lookup[model.id] }
   end
   ```
 

--- a/lib/brainstem/concerns/lookup.rb
+++ b/lib/brainstem/concerns/lookup.rb
@@ -23,11 +23,7 @@ module Brainstem
       end
 
       def key_for_lookup
-        if self.class == Brainstem::DSL::Association
-          :associations
-        elsif self.class == Brainstem::DSL::Field
-          :fields
-        end
+        raise(StandardError 'Implement `key_for_lookup` when including Lookup Module.')
       end
     end
   end

--- a/lib/brainstem/concerns/lookup.rb
+++ b/lib/brainstem/concerns/lookup.rb
@@ -1,0 +1,34 @@
+module Brainstem
+  module Concerns
+    module Lookup
+      extend ActiveSupport::Concern
+
+      def run_on_with_lookup(model, context, helper_instance)
+        context[:lookup][key_for_lookup][name] ||= begin
+          proc = options[:lookup]
+          lookup = helper_instance.instance_exec(context[:models], &proc)
+          if !options[:lookup_fetch].present? && !lookup.respond_to?(:[])
+            raise(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
+          end
+
+          lookup
+        end
+
+        if options[:lookup_fetch]
+          proc = options[:lookup_fetch]
+          helper_instance.instance_exec(context[:lookup][key_for_lookup][name], model, &proc)
+        else
+          context[:lookup][key_for_lookup][name][model.id]
+        end
+      end
+
+      def key_for_lookup
+        if self.class == Brainstem::DSL::Association
+          :associations
+        elsif self.class == Brainstem::DSL::Field
+          :fields
+        end
+      end
+    end
+  end
+end

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -44,6 +44,12 @@ module Brainstem
       def always_return_ref_with_sti_base?
         options[:always_return_ref_with_sti_base]
       end
+
+      private
+
+      def key_for_lookup
+        :associations
+      end
     end
   end
 end

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -19,7 +19,7 @@ module Brainstem
       end
 
       def run_on(model, context, helper_instance = Object.new)
-        if options[:dynamic]
+        if options[:dynamic] && (!options[:lookup] || context[:models].size == 1)
           proc = options[:dynamic]
           if proc.arity > 0
             helper_instance.instance_exec(model, &proc)

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -48,7 +48,7 @@ module Brainstem
           proc = options[:lookup]
           lookup = helper_instance.instance_exec(context[:models], &proc)
           if !options[:lookup_fetch].present? && !lookup.respond_to?(:[])
-            raise(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+            raise(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
           end
 
           lookup

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -21,7 +21,7 @@ module Brainstem
       def run_on(model, context, helper_instance = Object.new)
         if options[:dynamic] && (!options[:lookup] || context[:models].size == 1)
           proc = options[:dynamic]
-          if proc.arity > 0
+          if proc.arity == 1
             helper_instance.instance_exec(model, &proc)
           else
             helper_instance.instance_exec(&proc)

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -19,17 +19,16 @@ module Brainstem
       end
 
       def run_on(model, context, helper_instance = Object.new)
-        dynamic_proc = options[:dynamic]
-        lookup_proc = options[:lookup]
-
-        if dynamic_proc
-          if dynamic_proc.arity > 0
-            helper_instance.instance_exec(model, &dynamic_proc)
+        if options[:dynamic]
+          proc = options[:dynamic]
+          if proc.arity > 0
+            helper_instance.instance_exec(model, &proc)
           else
-            helper_instance.instance_exec(&dynamic_proc)
+            helper_instance.instance_exec(&proc)
           end
-        elsif lookup_proc
-          context[:lookup][:associations][name] ||= helper_instance.instance_exec(context[:models], &lookup_proc)
+        elsif options[:lookup]
+          proc = options[:lookup]
+          context[:lookup][:associations][name] ||= helper_instance.instance_exec(context[:models], &proc)
           context[:lookup][:associations][name][model.id]
         else
           model.send(method_name)

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -11,7 +11,7 @@ module Brainstem
       end
 
       def method_name
-        if options[:dynamic]
+        if options[:dynamic] || options[:lookup]
           nil
         else
           (options[:via].presence || name).to_s

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -48,7 +48,7 @@ module Brainstem
           proc = options[:lookup]
           lookup = helper_instance.instance_exec(context[:models], &proc)
           if !options[:lookup_fetch].present? && !lookup.respond_to?(:[])
-            raise(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s assocation(s) from the lookup. Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+            raise(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
           end
 
           lookup

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -1,6 +1,10 @@
+require 'brainstem/concerns/lookup'
+
 module Brainstem
   module DSL
     class Association
+      include Brainstem::Concerns::Lookup
+
       attr_reader :name, :target_class, :description, :options
 
       def initialize(name, target_class, description, options)
@@ -39,27 +43,6 @@ module Brainstem
 
       def always_return_ref_with_sti_base?
         options[:always_return_ref_with_sti_base]
-      end
-
-      private
-
-      def run_on_with_lookup(model, context, helper_instance)
-        context[:lookup][:associations][name] ||= begin
-          proc = options[:lookup]
-          lookup = helper_instance.instance_exec(context[:models], &proc)
-          if !options[:lookup_fetch].present? && !lookup.respond_to?(:[])
-            raise(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
-          end
-
-          lookup
-        end
-
-        if options[:lookup_fetch]
-          proc = options[:lookup_fetch]
-          helper_instance.instance_exec(context[:lookup][:associations][name], model, &proc)
-        else
-          context[:lookup][:associations][name][model.id]
-        end
       end
     end
   end

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -29,7 +29,12 @@ module Brainstem
         elsif options[:lookup]
           proc = options[:lookup]
           context[:lookup][:associations][name] ||= helper_instance.instance_exec(context[:models], &proc)
-          context[:lookup][:associations][name][model.id]
+          if options[:lookup_fetch]
+            proc = options[:lookup_fetch]
+            helper_instance.instance_exec(context[:lookup][:associations][name], model, &proc)
+          else
+            context[:lookup][:associations][name][model.id]
+          end
         else
           model.send(method_name)
         end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -42,7 +42,12 @@ module Brainstem
         elsif options[:lookup]
           proc = options[:lookup]
           context[:lookup][:fields][name] ||= helper_instance.instance_exec(context[:models], &proc)
-          context[:lookup][:fields][name][model.id]
+          if options[:lookup_fetch]
+            proc = options[:lookup_fetch]
+            helper_instance.instance_exec(context[:lookup][:fields][name], model, &proc)
+          else
+            context[:lookup][:fields][name][model.id]
+          end
         else
           model.send(method_name)
         end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -57,6 +57,12 @@ module Brainstem
           presenter_conditionals[conditional].matches?(model, helper_instance, conditional_cache)
         }
       end
+
+      private
+
+      def key_for_lookup
+        :fields
+      end
     end
   end
 end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -1,6 +1,10 @@
+require 'brainstem/concerns/lookup'
+
 module Brainstem
   module DSL
     class Field
+      include Brainstem::Concerns::Lookup
+
       attr_reader :name, :type, :description, :conditionals, :options
 
       def initialize(name, type, description, options)
@@ -52,27 +56,6 @@ module Brainstem
         conditionals.all? { |conditional|
           presenter_conditionals[conditional].matches?(model, helper_instance, conditional_cache)
         }
-      end
-
-      private
-
-      def run_on_with_lookup(model, context, helper_instance)
-        context[:lookup][:fields][name] ||= begin
-          proc = options[:lookup]
-          lookup = helper_instance.instance_exec(context[:models], &proc)
-          if !options[:lookup_fetch].present? && !lookup.respond_to?(:[])
-            raise(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
-          end
-
-          lookup
-        end
-
-        if options[:lookup_fetch]
-          proc = options[:lookup_fetch]
-          helper_instance.instance_exec(context[:lookup][:fields][name], model, &proc)
-        else
-          context[:lookup][:fields][name][model.id]
-        end
       end
     end
   end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -32,7 +32,7 @@ module Brainstem
       end
 
       def run_on(model, context, helper_instance = Object.new)
-        if options[:dynamic]
+        if options[:dynamic] && (!options[:lookup] || context[:models].size == 1)
           proc = options[:dynamic]
           if proc.arity > 0
             helper_instance.instance_exec(model, &proc)

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -61,7 +61,7 @@ module Brainstem
           proc = options[:lookup]
           lookup = helper_instance.instance_exec(context[:models], &proc)
           if !options[:lookup_fetch].present? && !lookup.respond_to?(:[])
-            raise(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s value. Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+            raise(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
           end
 
           lookup

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -34,7 +34,7 @@ module Brainstem
       def run_on(model, context, helper_instance = Object.new)
         if options[:dynamic] && (!options[:lookup] || context[:models].size == 1)
           proc = options[:dynamic]
-          if proc.arity > 0
+          if proc.arity == 1
             helper_instance.instance_exec(model, &proc)
           else
             helper_instance.instance_exec(&proc)

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -31,7 +31,7 @@ module Brainstem
         options[:optional]
       end
 
-      def run_on(model, helper_instance = Object.new)
+      def run_on(model, context, helper_instance = Object.new)
         if options[:dynamic]
           proc = options[:dynamic]
           if proc.arity > 0
@@ -39,6 +39,10 @@ module Brainstem
           else
             helper_instance.instance_exec(&proc)
           end
+        elsif options[:lookup]
+          proc = options[:lookup]
+          context[:lookup][:fields][name] ||= helper_instance.instance_exec(context[:models], &proc)
+          context[:lookup][:fields][name][model.id]
         else
           model.send(method_name)
         end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -16,7 +16,7 @@ module Brainstem
       end
 
       def method_name
-        if options[:dynamic]
+        if options[:dynamic] || options[:lookup]
           nil
         else
           (options[:via].presence || name).to_s

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -78,7 +78,9 @@ module Brainstem
         associations:                 configuration[:associations],
         reflections:                  reflections_for_model(models.first),
         association_objects_by_name:  association_objects_by_name,
-        optional_fields:              options[:optional_fields] || []
+        optional_fields:              options[:optional_fields] || [],
+        models:                       models,
+        lookup:                       empty_lookup_cache(configuration[:fields].keys, association_objects_by_name.keys)
       }
 
       sanitized_association_names = association_objects_by_name.values.map(&:method_name)
@@ -271,7 +273,7 @@ module Brainstem
         # If this association has been explictly requested, execute the association here.  Additionally, store
         # the loaded models in the :load_associations_into hash for later use.
         if context[:association_objects_by_name][external_name]
-          associated_model_or_models = association.run_on(model, context[:helper_instance])
+          associated_model_or_models = association.run_on(model, context, context[:helper_instance])
 
           if options[:load_associations_into]
             Array(associated_model_or_models).flatten.each do |associated_model|
@@ -349,6 +351,16 @@ module Brainstem
     # Find the global presenter collection for our namespace.
     def presenter_collection
       Brainstem.presenter_collection(self.class.namespace)
+    end
+
+    # @api protected
+    # Create an empty lookup cache with the fields and associations as keys and nil for the values
+    # @return [Hash]
+    def empty_lookup_cache(field_keys, association_keys)
+      {
+        fields: Hash[field_keys.map { |key| [key, nil] }],
+        associations: Hash[association_keys.map { |key| [key, nil] }]
+      }
     end
   end
 end

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -251,7 +251,7 @@ module Brainstem
         case field
           when DSL::Field
             if field.conditionals_match?(model, context[:conditionals], context[:helper_instance], context[:conditional_cache]) && field.optioned?(context[:optional_fields])
-              result[name] = field.run_on(model, context[:helper_instance])
+              result[name] = field.run_on(model, context, context[:helper_instance])
             end
           when DSL::Configuration
             result[name] ||= {}

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -73,6 +73,18 @@ describe Brainstem::DSL::Association do
         end
       end
 
+      context 'with no lookup_fetch' do
+        context 'when the lookup returns on object which does not respond to []' do
+          let(:options) { { lookup: lambda { |models| nil } } }
+
+          it 'should raise error explaining the default lookup fetch relys on [] to access the model\'s value from the lookup' do
+            expect {
+              association.run_on(first_model, context)
+            }.to raise_error(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s value from the lookup. Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+          end
+        end
+      end
+
       context 'when given a lookup_fetch' do
         let(:options) {
           {

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -72,6 +72,23 @@ describe Brainstem::DSL::Association do
           expect(association.run_on(second_model, context, instance)).to eq('Nate')
         end
       end
+
+      context 'when given a lookup_fetch' do
+        let(:options) {
+          {
+            lookup: lambda { |models| Hash[models.map { |model| [model.id, model.username] }] },
+            lookup_fetch: lambda { |lookup, model| some_instance_method; lookup[model.id] }
+          }
+        }
+
+        it 'returns the value from the lookup using the lookup_fetch lambda' do
+          context[:lookup][:associations][name.to_s] = {}
+          context[:lookup][:associations][name.to_s][first_model.id] = "Ben's stubbed out Name"
+          instance = Object.new
+          mock(instance).some_instance_method
+          expect(association.run_on(first_model, context, instance)).to eq("Ben's stubbed out Name")
+        end
+      end
     end
   end
 end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -7,13 +7,14 @@ describe Brainstem::DSL::Association do
   let(:description) { "This object's user" }
   let(:options) { { } }
   let(:association) { Brainstem::DSL::Association.new(name, target_class, description, options) }
+  let(:context) { { } }
 
   describe "#run_on" do
     context 'with no special options' do
       it 'calls the method by name on the model' do
         object = Object.new
         mock(object).user
-        association.run_on(object)
+        association.run_on(object, context)
       end
     end
 
@@ -23,7 +24,7 @@ describe Brainstem::DSL::Association do
       it 'calls the method named in :via on the model' do
         object = Object.new
         mock(object).user2
-        association.run_on(object)
+        association.run_on(object, context)
       end
     end
 
@@ -33,7 +34,7 @@ describe Brainstem::DSL::Association do
       it 'calls the lambda in the context of the given instance' do
         instance = Object.new
         mock(instance).some_instance_method
-        expect(association.run_on(:anything, instance)).to eq :return_value
+        expect(association.run_on(:anything, context, instance)).to eq :return_value
       end
     end
   end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -78,10 +78,10 @@ describe Brainstem::DSL::Association do
         context 'when the lookup returns on object which does not respond to []' do
           let(:options) { { lookup: lambda { |models| nil } } }
 
-          it 'should raise error explaining the default lookup fetch relys on [] to access the model\'s value from the lookup' do
+          it 'should raise error explaining the default lookup fetch relies on [] to access the model\'s value from the lookup' do
             expect {
               association.run_on(first_model, context)
-            }.to raise_error(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+            }.to raise_error(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
           end
         end
       end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -80,7 +80,7 @@ describe Brainstem::DSL::Association do
           it 'should raise error explaining the default lookup fetch relys on [] to access the model\'s value from the lookup' do
             expect {
               association.run_on(first_model, context)
-            }.to raise_error(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s value from the lookup. Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+            }.to raise_error(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
           end
         end
       end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -7,9 +7,10 @@ describe Brainstem::DSL::Association do
   let(:description) { "This object's user" }
   let(:options) { { } }
   let(:association) { Brainstem::DSL::Association.new(name, target_class, description, options) }
-  let(:context) { { } }
 
   describe "#run_on" do
+    let(:context) { { } }
+
     context 'with no special options' do
       it 'calls the method by name on the model' do
         object = Object.new
@@ -39,21 +40,20 @@ describe Brainstem::DSL::Association do
     end
 
     context 'when given a lookup lambda' do
-      let(:model_id) { 23 }
       let(:options) { { lookup: lambda { |models| some_instance_method; Hash[models.map { |model| [model.id, model.username] }] } } }
       let(:first_model) { target_class.create(username: 'Ben') }
       let(:second_model) { target_class.create(username: 'Nate') }
       let(:context) {
         {
-            lookup: Brainstem::Presenter.new.send(:empty_lookup_cache, [], [name.to_s]),
-            models: [first_model, second_model]
+          lookup: Brainstem::Presenter.new.send(:empty_lookup_cache, [], [name.to_s]),
+          models: [first_model, second_model]
         }
       }
-      # context => {:lookup=>{:fields=>{}, :associations=>{'user'=>nil}}}
+      # {:lookup=>{:fields=>{}, :associations=>{"user"=>nil}}}
 
       context 'The first model is ran' do
-        it 'builds lookup cache and returns the value' do
-          expect(context[:lookup][:associations][name]).to eq(nil)
+        it 'builds lookup cache and returns the value for the first model' do
+          expect(context[:lookup][:associations][name.to_s]).to eq(nil)
           instance = Object.new
           mock(instance).some_instance_method
           expect(association.run_on(first_model, context, instance)).to eq('Ben')

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -86,10 +86,10 @@ describe Brainstem::DSL::Field do
         context 'when the lookup returns on object which does not respond to []' do
           let(:options) { { lookup: lambda { |models| nil } } }
 
-          it 'should raise error explaining the default lookup fetch relys on [] to access the model\'s value from the lookup' do
+          it 'should raise error explaining the default lookup fetch relies on [] to access the model\'s value from the lookup' do
             expect {
               field.run_on(first_model, context)
-            }.to raise_error(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s value. Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+            }.to raise_error(StandardError, 'Brainstem expects the return result of the `lookup` to be a Hash since it must respond to [] in order to access the model\'s assocation(s). Default: lookup_fetch: lambda { |lookup, model| lookup[model.id] }`')
           end
         end
       end

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -80,6 +80,23 @@ describe Brainstem::DSL::Field do
           expect(field.run_on(second_model, context, instance)).to eq("Nate's Project")
         end
       end
+
+      context 'on :lookup_fetch' do
+        let(:options) {
+          {
+            lookup: lambda { |models| Hash[models.map { |model| [model.id, model.title] }] },
+            lookup_fetch: lambda { |lookup, model| some_instance_method; lookup[model.id] }
+          }
+        }
+
+        it 'returns the value from the lookup using the lookup_fetch lambda' do
+          context[:lookup][:fields][name.to_s] = {}
+          context[:lookup][:fields][name.to_s][first_model.id] = "Ben's stubbed out Project"
+          instance = Object.new
+          mock(instance).some_instance_method
+          expect(field.run_on(first_model, context, instance)).to eq("Ben's stubbed out Project")
+        end
+      end
     end
 
     context 'on non-:dynamic fields' do

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -81,6 +81,18 @@ describe Brainstem::DSL::Field do
         end
       end
 
+      context 'with no lookup_fetch' do
+        context 'when the lookup returns on object which does not respond to []' do
+          let(:options) { { lookup: lambda { |models| nil } } }
+
+          it 'should raise error explaining the default lookup fetch relys on [] to access the model\'s value from the lookup' do
+            expect {
+              field.run_on(first_model, context)
+            }.to raise_error(StandardError, 'The returned result of the lookup lambda must respond to [] since the default `lookup_fetch` relys on the `[] method` in order to access the model\'s value. Default: lookup_fetch: lambda { |lookup, model| lookup[:assoication_name][model.id] }`')
+          end
+        end
+      end
+
       context 'on :lookup_fetch' do
         let(:options) {
           {

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -19,6 +19,10 @@ class WorkspacePresenter < Brainstem::Presenter
     field :description, :string
     field :updated_at, :datetime
     field :dynamic_title, :string, dynamic: lambda { |model| "title: #{model.title}" }
+    field :lookup_title, :string, lookup: lambda { |models| Hash[models.map { |model| [model.id, "lookup_title: #{model.title}"] }] }
+    field :lookup_fetch_title, :string,
+          lookup: lambda { |models| Hash[models.map { |model| [model.id, model.title] }] },
+          lookup_fetch: lambda { |lookup, model| "lookup_fetch_title: #{lookup[model.id]}" }
     field :expensive_title, :string, via: :title, optional: true
     field :expensive_title2, :string, via: :title, optional: true
     field :expensive_title3, :string, via: :title, optional: true


### PR DESCRIPTION
This PR allows fields and associations to define a lookup option in order to generate a lookup cache which will run once for all the models presented. When a model is presented, who's field/association defines a lookup option, it will refer to the cache to find its value rather than redoing the work.

### Before
```
      fields do
        field :complicated_field, :string,
              dynamic: lambda { |model| model.complicated_query(current_user) } # This is an N + 1
        #...
      end
```

### After
```
      fields do
        field :complicated_field, :string,
              # This should return a hash with the keys as model ids and their values as the values for this field
              lookup: lambda { |models| ComplicatedQueryServiceObject(current_user, models).group_by { |model| model.id } } 
        #...
      end
```

TODO:
- [x] Add specs for Associations
- [x] Add specs for Fields
- [x] Implement lookup support for Fields
- [x] Add specs and implementation for `lookup_fetch` for Fields
- [x] Add specs and implementation for `lookup_fetch` for Associations
- [x] Add README docs with example of `lookup` and `lookup_fetch`