### PR TITLE
Fix duplicates when paginating over records sorted by non-unique values

### DIFF
--- a/brainstem.gemspec
+++ b/brainstem.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = Brainstem::VERSION
 
   gem.add_dependency "activerecord", ">= 3.2"
-  gem.add_dependency "activesupport", "4.2.7"
+  gem.add_dependency "activesupport", ">= 4.1"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "redcarpet" # for markdown in yard

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -195,7 +195,7 @@ module Brainstem
       sort_name, direction = calculate_sort_name_and_direction(user_params)
       order = configuration[:sort_orders][sort_name]
 
-      case order
+      ordered_scope = case order
         when Proc
           fresh_helper_instance.instance_exec(scope, direction, &order)
         when nil
@@ -203,6 +203,10 @@ module Brainstem
         else
           scope.reorder(order.to_s + " " + direction)
       end
+
+      fallback_deterministic_sort = "#{scope.table.name}.#{scope.model.primary_key} desc"
+      # Chain on a tiebreaker sort to ensure deterministic ordering of multiple pages of data
+      ordered_scope.order(fallback_deterministic_sort)
     end
 
     # Execute the stored search block

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -206,14 +206,23 @@ module Brainstem
 
       fallback_deterministic_sort = assemble_primary_key_sort(scope)
       # Chain on a tiebreaker sort to ensure deterministic ordering of multiple pages of data
-      ordered_scope.order(fallback_deterministic_sort)
+
+      if fallback_deterministic_sort
+        ordered_scope.order(fallback_deterministic_sort)
+      else
+        ordered_scope
+      end
     end
 
     def assemble_primary_key_sort(scope)
-      table_name = scope.connection.quote_table_name(scope.table.name)
-      primary_key = scope.connection.quote_column_name(scope.model.primary_key)
+      table_name = scope.table.name
+      primary_key = scope.model.primary_key
 
-      "#{table_name}.#{primary_key} ASC"
+      if table_name && primary_key
+        "#{scope.connection.quote_table_name(table_name)}.#{scope.connection.quote_column_name(primary_key)} ASC"
+      else
+        nil
+      end
     end
     private :assemble_primary_key_sort
 

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -204,7 +204,7 @@ module Brainstem
           scope.reorder(order.to_s + " " + direction)
       end
 
-      fallback_deterministic_sort = "#{scope.table.name}.#{scope.model.primary_key} desc"
+      fallback_deterministic_sort = "#{scope.table.name}.#{scope.model.primary_key} asc"
       # Chain on a tiebreaker sort to ensure deterministic ordering of multiple pages of data
       ordered_scope.order(fallback_deterministic_sort)
     end

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -777,7 +777,7 @@ describe Brainstem::Presenter do
 
       it 'does not add a fallback deterministic sort, and you deserve whatever fate befalls you' do
         sql = presenter.apply_ordering_to_scope(scope, order).to_sql
-        expect(sql).to eq("SELECT \"workspaces\".* FROM \"workspaces\" WHERE \"workspaces\".\"type\" IN ('Cthulhu')  ORDER BY workspaces.updated_at asc")
+        expect(sql).to eq("SELECT \"workspaces\".* FROM \"workspaces\" WHERE \"workspaces\".\"type\" IN ('Cthulhu') ORDER BY workspaces.updated_at asc")
       end
     end
   end

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -762,6 +762,24 @@ describe Brainstem::Presenter do
         expect(sql).to match(/order by "workspaces"."id" ASC/i)
       end
     end
+
+    context 'when the table has no primary key' do
+      let(:scope) { Cthulhu.where(nil) }
+      let(:order) { { 'order' => 'updated_at:asc' } }
+
+      before do
+        class Cthulhu < Workspace
+          self.primary_key = nil
+        end
+
+        presenter_class.sort_order :updated_at, 'workspaces.updated_at'
+      end
+
+      it 'does not add a fallback deterministic sort, and you deserve whatever fate befalls you' do
+        sql = presenter.apply_ordering_to_scope(scope, order).to_sql
+        expect(sql).to eq("SELECT \"workspaces\".* FROM \"workspaces\" WHERE \"workspaces\".\"type\" IN ('Cthulhu')  ORDER BY workspaces.updated_at asc")
+      end
+    end
   end
 
   describe "#calculate_sort_name_and_direction" do

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -680,37 +680,80 @@ describe Brainstem::Presenter do
     end
   end
 
-  describe "#apply_ordering_to_scope" do
+  describe '#apply_ordering_to_scope' do
     let(:presenter_class) { WorkspacePresenter }
     let(:presenter) { presenter_class.new }
     let(:scope) { Workspace.where(nil) }
 
     it 'uses #calculate_sort_name_and_direction to extract a sort name and direction from user params' do
-      presenter_class.sort_order :title, "workspaces.title"
+      presenter_class.sort_order :title, 'workspaces.title'
       mock(presenter).calculate_sort_name_and_direction('order' => 'title:desc') { ['title', 'desc'] }
       presenter.apply_ordering_to_scope(scope, 'order' => 'title:desc')
     end
 
-    it 'runs procs in the context of any helpers' do
-      presenter_class.helper do
-        def some_method
+    context 'when the sort is a proc' do
+      it 'runs procs in the context of any helpers' do
+        presenter_class.helper do
+          def some_method
+          end
         end
+
+        direction = nil
+        presenter_class.sort_order(:title) do |scope, d|
+          some_method
+          direction = d
+          scope
+        end
+
+        presenter.apply_ordering_to_scope(scope, 'order' => 'title:asc')
+        expect(direction).to eq 'asc'
       end
 
-      direction = nil
-      presenter_class.sort_order(:title) do |scope, d|
-        some_method
-        direction = d
-        scope
+      it 'can chain multiple sorts together' do
+        presenter_class.sort_order(:title) do |scope|
+          scope.order('workspaces.title desc').order('workspaces.id desc')
+        end
+
+        sql = presenter.apply_ordering_to_scope(scope, 'order' => 'title').to_sql
+        expect(sql).to match(/order by workspaces.title desc, workspaces.id desc/i)
       end
-      presenter.apply_ordering_to_scope(scope, 'order' => 'title:asc')
-      expect(direction).to eq 'asc'
+
+      it 'chains the primary key onto the end' do
+        presenter_class.sort_order(:title) do |scope|
+          scope.order('workspaces.title desc')
+        end
+
+        sql = presenter.apply_ordering_to_scope(scope, 'order' => 'title').to_sql
+        expect(sql).to match(/order by workspaces.title desc, workspaces.id desc/i)
+      end
     end
 
-    it 'applies the named ordering in the given direction' do
-      direction = nil
-      presenter_class.sort_order :title, 'workspaces.title'
-      expect(presenter.apply_ordering_to_scope(scope, 'order' => 'title:asc').to_sql).to match(/order by workspaces.title asc/i)
+    context 'when the sort is not a proc' do
+      it 'applies the named ordering in the given direction' do
+        presenter_class.sort_order :title, 'workspaces.title'
+        expect(presenter.apply_ordering_to_scope(scope, 'order' => 'title:asc').to_sql).to match(/order by workspaces.title asc/i)
+      end
+
+      describe 'deterministic ordering' do
+        let(:order) { { 'order' => 'title:asc' } }
+
+        before do
+          presenter_class.sort_order :title, 'workspaces.title'
+          presenter_class.sort_order :id, 'workspaces.id'
+        end
+
+        it 'adds the primary key as a fallback sort' do
+          sql = presenter.apply_ordering_to_scope(scope, order).to_sql
+          expect(sql).to match(/order by workspaces.title asc, workspaces.id desc/i)
+        end
+      end
+    end
+
+    context 'when the sort is nil' do
+      it 'orders by the primary key' do
+        sql = presenter.apply_ordering_to_scope(scope, '').to_sql
+        expect(sql).to match(/order by workspaces.id desc/i)
+      end
     end
   end
 

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -724,7 +724,7 @@ describe Brainstem::Presenter do
         end
 
         sql = presenter.apply_ordering_to_scope(scope, 'order' => 'title').to_sql
-        expect(sql).to match(/order by workspaces.title desc, workspaces.id desc/i)
+        expect(sql).to match(/order by workspaces.title desc, workspaces.id asc/i)
       end
     end
 
@@ -744,7 +744,7 @@ describe Brainstem::Presenter do
 
         it 'adds the primary key as a fallback sort' do
           sql = presenter.apply_ordering_to_scope(scope, order).to_sql
-          expect(sql).to match(/order by workspaces.title asc, workspaces.id desc/i)
+          expect(sql).to match(/order by workspaces.title asc, workspaces.id asc/i)
         end
       end
     end
@@ -752,7 +752,7 @@ describe Brainstem::Presenter do
     context 'when the sort is nil' do
       it 'orders by the primary key' do
         sql = presenter.apply_ordering_to_scope(scope, '').to_sql
-        expect(sql).to match(/order by workspaces.id desc/i)
+        expect(sql).to match(/order by workspaces.id asc/i)
       end
     end
   end

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -715,7 +715,7 @@ describe Brainstem::Presenter do
         end
 
         sql = presenter.apply_ordering_to_scope(scope, 'order' => 'title').to_sql
-        expect(sql).to match(/order by workspaces.title desc, workspaces.id desc, workspaces.id asc/i)
+        expect(sql).to match(/order by workspaces.title desc, workspaces.id desc, "workspaces"."id" ASC/i)
         # this should be ok, since the first id sort will never have a tie
       end
 
@@ -725,21 +725,32 @@ describe Brainstem::Presenter do
         end
 
         sql = presenter.apply_ordering_to_scope(scope, 'order' => 'title').to_sql
-        expect(sql).to match(/order by workspaces.title desc, workspaces.id asc/i)
+        expect(sql).to match(/order by workspaces.title desc, "workspaces"."id" ASC/i)
       end
     end
 
     context 'when the sort is not a proc' do
-      let(:order) { { 'order' => 'title:asc' } }
-
       before do
         presenter_class.sort_order :title, 'workspaces.title'
         presenter_class.sort_order :id, 'workspaces.id'
       end
 
-      it 'applies the named ordering in the given direction and adds the primary key as a fallback sort' do
-        sql = presenter.apply_ordering_to_scope(scope, order).to_sql
-        expect(sql).to match(/order by workspaces.title asc, workspaces.id asc/i)
+      context 'and is a string' do
+        let(:order) { { 'order' => 'title:asc' } }
+
+        it 'applies the named ordering in the given direction and adds the primary key as a fallback sort' do
+          sql = presenter.apply_ordering_to_scope(scope, order).to_sql
+          expect(sql).to match(/ORDER BY workspaces.title asc, "workspaces"."id" ASC/i)
+        end
+      end
+
+      context 'and is a symbol' do
+        let(:order) { { 'order' => :title } }
+
+        it 'applies the named ordering in the given direction and adds the primary key as a fallback sort' do
+          sql = presenter.apply_ordering_to_scope(scope, order).to_sql
+          expect(sql).to match(/order by workspaces.title asc, "workspaces"."id" ASC/i)
+        end
       end
     end
 
@@ -748,7 +759,7 @@ describe Brainstem::Presenter do
 
       it 'orders by the primary key' do
         sql = presenter.apply_ordering_to_scope(scope, order).to_sql
-        expect(sql).to match(/order by workspaces.id asc/i)
+        expect(sql).to match(/order by "workspaces"."id" ASC/i)
       end
     end
   end


### PR DESCRIPTION
Right now, as an example, if you have many records with identical `updated_at` timestamps, and you sort by `updated_at`, the resulting sort will be non-deterministic, and records will randomly show up multiple times on different pages.

We are adding the primary key (descending) as a fallback tie-breaker sort to _all_ queries -- one possible worry here is that it could adversely affect performance, but we think that most databases will do the right thing if given a query of `order by id desc, id desc`.