### PR TITLE
Refactor lookup to take precendece over dynamic lambda

### DIFF
--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -23,15 +23,15 @@ module Brainstem
       end
 
       def run_on(model, context, helper_instance = Object.new)
-        if options[:dynamic] && (!options[:lookup] || context[:models].size == 1)
+        if options[:lookup]
+          run_on_with_lookup(model, context, helper_instance)
+        elsif options[:dynamic]
           proc = options[:dynamic]
           if proc.arity == 1
             helper_instance.instance_exec(model, &proc)
           else
             helper_instance.instance_exec(&proc)
           end
-        elsif options[:lookup]
-          run_on_with_lookup(model, context, helper_instance)
         else
           model.send(method_name)
         end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -36,15 +36,15 @@ module Brainstem
       end
 
       def run_on(model, context, helper_instance = Object.new)
-        if options[:dynamic] && (!options[:lookup] || context[:models].size == 1)
+        if options[:lookup]
+          run_on_with_lookup(model, context, helper_instance)
+        elsif options[:dynamic]
           proc = options[:dynamic]
           if proc.arity == 1
             helper_instance.instance_exec(model, &proc)
           else
             helper_instance.instance_exec(&proc)
           end
-        elsif options[:lookup]
-          run_on_with_lookup(model, context, helper_instance)
         else
           model.send(method_name)
         end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -94,24 +94,11 @@ describe Brainstem::DSL::Association do
           }
         }
 
-        context 'when presenting one model' do
-          let(:models) { [first_model] }
-
-          it 'calls the dynamic lambda and not the lookup lambda' do
-            instance = Object.new
-            mock(instance).dynamic_instance_method
-            mock(instance).lookup_instance_method.never
-            expect(association.run_on(first_model, context, instance)).to eq 'Ben'
-          end
-        end
-
-        context 'when presenting more than one model' do
-          it 'calls the lookup lambda and not the dynamic lambda' do
-            instance = Object.new
-            mock(instance).lookup_instance_method
-            mock(instance).dynamic_instance_method.never
-            expect(association.run_on(first_model, context, instance)).to eq 'Ben'
-          end
+        it 'calls the dynamic lambda and not the lookup lambda' do
+          instance = Object.new
+          mock(instance).dynamic_instance_method.never
+          mock(instance).lookup_instance_method
+          expect(association.run_on(first_model, context, instance)).to eq 'Ben'
         end
       end
 

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -94,7 +94,7 @@ describe Brainstem::DSL::Association do
           }
         }
 
-        it 'calls the dynamic lambda and not the lookup lambda' do
+        it 'calls the lookup lambda and not the dynamic lambda' do
           instance = Object.new
           mock(instance).dynamic_instance_method.never
           mock(instance).lookup_instance_method

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -102,24 +102,11 @@ describe Brainstem::DSL::Field do
           }
         }
 
-        context 'when presenting one model' do
-          let(:models) { [first_model] }
-
-          it 'calls the dynamic lambda and not the lookup lambda' do
-            instance = Object.new
-            mock(instance).dynamic_instance_method
-            mock(instance).lookup_instance_method.never
-            expect(field.run_on(first_model, context, instance)).to eq "Ben's Project"
-          end
-        end
-
-        context 'when presenting more than one model' do
-          it 'calls the lookup lambda and not the dynamic lambda' do
-            instance = Object.new
-            mock(instance).lookup_instance_method
-            mock(instance).dynamic_instance_method.never
-            expect(field.run_on(first_model, context, instance)).to eq "Ben's Project"
-          end
+        it 'does not use the dynamic lambda' do
+          instance = Object.new
+          mock(instance).dynamic_instance_method.never
+          mock(instance).lookup_instance_method
+          expect(field.run_on(first_model, context, instance)).to eq "Ben's Project"
         end
       end
 


### PR DESCRIPTION
@plainprogrammer ,

This PR is what we had outlined from our previous discussion [here](https://github.com/mavenlink/mavenlink/pull/6878#issuecomment-263328677). Now, if we define a `lookup` that will be ran instead of the `dynamic`. This way we do not run into the case where we are improving the performance of a field or association, adding a `lookup`, and then not having the previous specs cover the new `lookup`.

As a follow up, it might make sense to delete the old dynamics, thoughts?

I made a mavenlink PR just, just to see if we get a passing build on Circle CI 
https://github.com/mavenlink/mavenlink/pull/7141

cc. @shirish-pampoorickal 