### PR TITLE
Update RSpec to version 3.5 & Patch RR

### DIFF
--- a/brainstem.gemspec
+++ b/brainstem.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "redcarpet" # for markdown in yard
   gem.add_development_dependency "rr"
-  gem.add_development_dependency "rspec", "2.99"
+  gem.add_development_dependency "rspec", "3.5"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "database_cleaner"
   gem.add_development_dependency "yard"

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -43,7 +43,7 @@ module Brainstem
           offset = limit * (calculate_page - 1)
         end
 
-        scope.limit(limit).offset(offset).uniq
+        scope.limit(limit).offset(offset).distinct
       end
     end
   end

--- a/lib/brainstem/query_strategies/filter_or_search.rb
+++ b/lib/brainstem/query_strategies/filter_or_search.rb
@@ -76,7 +76,7 @@ module Brainstem
           offset = limit * (calculate_page - 1)
         end
 
-        [scope.limit(limit).offset(offset).uniq, scope.select("distinct #{scope.connection.quote_table_name @options[:table_name]}.id").count]
+        [scope.limit(limit).offset(offset).distinct, scope.select("distinct #{scope.connection.quote_table_name @options[:table_name]}.id").count]
       end
 
       def handle_only(scope, only)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'pry-nav'
 require 'brainstem'
 require_relative 'spec_helpers/schema'
 require_relative 'spec_helpers/db'
+require_relative 'spec_helpers/rr'
 
 DatabaseCleaner.strategy = :transaction
 

--- a/spec/spec_helpers/rr.rb
+++ b/spec/spec_helpers/rr.rb
@@ -1,0 +1,11 @@
+require 'rr'
+
+module RSpec
+  module Core
+    module MockingAdapters
+      module RR
+        include ::RR::DSL
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Update RSpec to 3.5
- Add RR patch to make it work with the RSpec version
- Get rid of deprecation warnings

- Another PR https://github.com/mavenlink/brainstem/pull/88 has been created to make brainstem compatible with Ruby 1.9.3 & greater