### PR TITLE
Deprecate description param as a string. Going forward the `info` option will be used for the description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
++ **1.0.0.pre.2** - _04/12/2017_
+  - Added support for specifying the description for conditionals, fields and associations with the `info` key in the options hash.
+  - Added a deprecation warning when description param is specified as a string and not with the `info` key in the options hash.
+  - Fixed: support for conditional, field and association options to be a hash with indifferent access.
+
 + **1.0.0.pre.1** - _03/07/2017_
   - Implemented new presenter DSL.
   - Added controller helpers for presenting errors.

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -5,13 +5,16 @@ module Brainstem
     class Association
       include Brainstem::Concerns::Lookup
 
-      attr_reader :name, :target_class, :description, :options
+      attr_reader :name, :target_class, :options
 
-      def initialize(name, target_class, description, options)
+      def initialize(name, target_class, options)
         @name = name.to_s
         @target_class = target_class
-        @description = description
         @options = options
+      end
+
+      def description
+        options[:info].presence
       end
 
       def method_name

--- a/lib/brainstem/dsl/associations_block.rb
+++ b/lib/brainstem/dsl/associations_block.rb
@@ -3,8 +3,8 @@ module Brainstem
     module PresenterDSL
       class AssociationsBlock < BaseBlock
         def association(name, target_class, *args)
-          description, options = parse_args(args)
-          configuration[:associations][name] = DSL::Association.new(name, target_class, description, block_options.merge(options))
+          options = parse_args(args)
+          configuration[:associations][name] = DSL::Association.new(name, target_class, block_options.merge(options))
         end
       end
     end

--- a/lib/brainstem/dsl/base_block.rb
+++ b/lib/brainstem/dsl/base_block.rb
@@ -27,10 +27,18 @@ module Brainstem
           if maybe_description.is_a?(Hash)
             options = options.merge(maybe_description)
           elsif maybe_description.present?            
+            deprecated_description_warning
             options[:info] = maybe_description
           end
 
           options
+        end
+
+        def deprecated_description_warning
+          ActiveSupport::Deprecation.warn(
+           'DEPRECATION_WARNING: Specifying description as the last parameter will be deprecated in the next version.' \
+           'Description can be specified with the `info` key in a hash. e.g. { info: "My description" }'
+          )
         end
       end
     end

--- a/lib/brainstem/dsl/base_block.rb
+++ b/lib/brainstem/dsl/base_block.rb
@@ -26,7 +26,7 @@ module Brainstem
 
           if maybe_description.is_a?(Hash)
             options = options.merge(maybe_description)
-          elsif maybe_description.present?            
+          elsif maybe_description.present?
             deprecated_description_warning
             options[:info] = maybe_description
           end
@@ -37,7 +37,8 @@ module Brainstem
         def deprecated_description_warning
           ActiveSupport::Deprecation.warn(
            'DEPRECATION_WARNING: Specifying description as the last parameter will be deprecated in the next version.' \
-           'Description can be specified with the `info` key in a hash. e.g. { info: "My description" }'
+           'Description can be specified with the `info` key in a hash. e.g. { info: "My description" }',
+           caller
           )
         end
       end

--- a/lib/brainstem/dsl/base_block.rb
+++ b/lib/brainstem/dsl/base_block.rb
@@ -32,7 +32,6 @@ module Brainstem
 
           options
         end
-        end
       end
     end
   end

--- a/lib/brainstem/dsl/base_block.rb
+++ b/lib/brainstem/dsl/base_block.rb
@@ -37,7 +37,7 @@ module Brainstem
         def deprecated_description_warning
           ActiveSupport::Deprecation.warn(
            'DEPRECATION_WARNING: Specifying description as the last parameter will be deprecated in the next version.' \
-           'Description can be specified with the `info` key in a hash. e.g. { info: "My description" }',
+           'Description can be specified with the `info` key in the options hash. e.g. { info: "My description" }',
            caller
           )
         end

--- a/lib/brainstem/dsl/base_block.rb
+++ b/lib/brainstem/dsl/base_block.rb
@@ -22,8 +22,16 @@ module Brainstem
 
         def parse_args(args)
           options = args.last.is_a?(Hash) ? args.pop : {}
-          description = args.shift
-          [description, options]
+          maybe_description = args.shift
+
+          if maybe_description.is_a?(Hash)
+            options = options.merge(maybe_description)
+          elsif maybe_description.present?            
+            options[:info] = maybe_description
+          end
+
+          options
+        end
         end
       end
     end

--- a/lib/brainstem/dsl/base_block.rb
+++ b/lib/brainstem/dsl/base_block.rb
@@ -21,17 +21,17 @@ module Brainstem
         end
 
         def parse_args(args)
-          options = args.last.is_a?(Hash) ? args.pop : {}
+          options = args.last.kind_of?(Hash) ? args.pop : {}
           maybe_description = args.shift
 
-          if maybe_description.is_a?(Hash)
+          if maybe_description.kind_of?(Hash)
             options = options.merge(maybe_description)
           elsif maybe_description.present?
             deprecated_description_warning
             options[:info] = maybe_description
           end
 
-          options
+          options.symbolize_keys
         end
 
         def deprecated_description_warning

--- a/lib/brainstem/dsl/conditional.rb
+++ b/lib/brainstem/dsl/conditional.rb
@@ -1,13 +1,17 @@
 module Brainstem
   module DSL
     class Conditional
-      attr_reader :name, :type, :action, :description
+      attr_reader :name, :type, :action, :options
 
-      def initialize(name, type, action, description)
+      def initialize(name, type, action, options = {})
         @name = name
         @type = type
         @action = action
-        @description = description
+        @options = options
+      end
+
+      def description
+        options[:info].presence
       end
 
       def matches?(model, helper_instance = Object.new, conditional_cache = { model: {}, request: {} })

--- a/lib/brainstem/dsl/conditionals_block.rb
+++ b/lib/brainstem/dsl/conditionals_block.rb
@@ -2,12 +2,29 @@ module Brainstem
   module Concerns
     module PresenterDSL
       class ConditionalsBlock < BaseBlock
-        def request(name, action, description = nil)
-          configuration[:conditionals][name] = DSL::Conditional.new(name, :request, action, description)
+        def request(name, action, *args)
+          options = parse_args(args)
+          configuration[:conditionals][name] = DSL::Conditional.new(name, :request, action, options)
         end
 
-        def model(name, action, description = nil)
-          configuration[:conditionals][name] = DSL::Conditional.new(name, :model, action, description)
+        def model(name, action, *args)
+          options = parse_args(args)
+          configuration[:conditionals][name] = DSL::Conditional.new(name, :model, action, options)
+        end
+      end
+
+      private
+
+      def parse_args(args)
+        if args.length == 1
+          description = args.first
+          if description.is_a?(String)
+            { info: description }
+          else
+            description
+          end
+        else
+          super(args)
         end
       end
     end

--- a/lib/brainstem/dsl/conditionals_block.rb
+++ b/lib/brainstem/dsl/conditionals_block.rb
@@ -19,6 +19,7 @@ module Brainstem
         if args.length == 1
           description = args.first
           if description.is_a?(String)
+            deprecated_description_warning
             { info: description }
           else
             description

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -5,14 +5,17 @@ module Brainstem
     class Field
       include Brainstem::Concerns::Lookup
 
-      attr_reader :name, :type, :description, :conditionals, :options
+      attr_reader :name, :type, :conditionals, :options
 
-      def initialize(name, type, description, options)
+      def initialize(name, type, options)
         @name = name.to_s
         @type = type
-        @description = description
         @conditionals = [options[:if]].flatten.compact
         @options = options
+      end
+
+      def description
+        options[:info].presence
       end
 
       def conditional?

--- a/lib/brainstem/dsl/fields_block.rb
+++ b/lib/brainstem/dsl/fields_block.rb
@@ -3,8 +3,8 @@ module Brainstem
     module PresenterDSL
       class FieldsBlock < BaseBlock
         def field(name, type, *args)
-          description, options = parse_args(args)
-          configuration[name] = DSL::Field.new(name, type, description, smart_merge(block_options, options))
+          options = parse_args(args)
+          configuration[name] = DSL::Field.new(name, type, smart_merge(block_options, options))
         end
 
         def fields(name, &block)

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "1.0.0.pre.1"
+  VERSION = "1.0.0.pre.2"
 end

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -96,6 +96,21 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(subclass.configuration[:conditionals][:title_is_hello].description).to eq "visible when the title is hello (in all caps)"
     end
 
+    context 'when options hash is a hash with indifferent access' do
+      before do
+        presenter_class.conditionals do
+          request :user_is_jane, lambda { current_user == 'jane' }, { info: 'visible only to Jane' }.with_indifferent_access
+        end
+      end
+
+      it 'is stored in the configuration correctly' do
+        expect(presenter_class.configuration[:conditionals].keys).to include('user_is_jane')
+        expect(presenter_class.configuration[:conditionals][:user_is_jane].action).to be_present
+        expect(presenter_class.configuration[:conditionals][:user_is_jane].type).to eq :request
+        expect(presenter_class.configuration[:conditionals][:user_is_jane].description).to eq 'visible only to Jane'
+      end
+    end
+
     context 'when description is specified in the deprecated format' do
       before do
         stub(ActiveSupport::Deprecation).warn.with(anything, anything)
@@ -245,6 +260,20 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(subclass.configuration[:fields][:new_nested_permissions]).to be_present
     end
 
+    context "when options is a hash with indifferent access" do
+      before do
+        presenter_class.fields do
+          field :synced_at, :datetime, { info: "Last time the object was synced" }.with_indifferent_access
+        end
+      end
+
+      it "is stored in the configuration correctly" do
+        expect(presenter_class.configuration[:fields].keys).to include('synced_at')
+        expect(presenter_class.configuration[:fields][:synced_at].type).to eq :datetime
+        expect(presenter_class.configuration[:fields][:synced_at].description).to eq 'Last time the object was synced'
+      end
+    end
+
     context "when description is specified in the deprecated format" do
       before do
         stub(ActiveSupport::Deprecation).warn.with(anything, anything)
@@ -307,6 +336,23 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(subclass.configuration[:associations][:tasks].options).to eq({ info: 'The Tasks in this Workspace' })
       expect(subclass.configuration[:associations][:lead_user].target_class).to eq User
       expect(subclass.configuration[:associations][:lead_user].description).to eq 'The user who runs this Workspace'
+    end
+
+    context "when options is a hash with indifferent access" do
+      before do
+        presenter_class.associations do
+          association :something_else, :polymorphic, { info: 'The other things in this Workspace', restrict_to_only: true }.with_indifferent_access
+        end
+      end
+
+      it "is stored in the configuration correctly" do
+        expect(presenter_class.configuration[:associations].keys).to include('something_else')
+        expect(presenter_class.configuration[:associations][:something_else].description).to eq 'The other things in this Workspace'
+        expect(presenter_class.configuration[:associations][:something_else].options).to eq(
+          info: 'The other things in this Workspace',
+          restrict_to_only: true
+        )
+      end
     end
 
     context "when description is specified in the deprecated format" do

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -98,6 +98,8 @@ describe Brainstem::Concerns::PresenterDSL do
 
     context 'when description is specified in the deprecated format' do
       before do
+        stub(ActiveSupport::Deprecation).warn.with(anything, anything)
+
         presenter_class.conditionals do
           model :user_is_jane, lambda { current_user == 'jane' }, 'visible only to Jane'
         end
@@ -108,6 +110,10 @@ describe Brainstem::Concerns::PresenterDSL do
         expect(presenter_class.configuration[:conditionals][:user_is_jane].action).to be_present
         expect(presenter_class.configuration[:conditionals][:user_is_jane].type).to eq :model
         expect(presenter_class.configuration[:conditionals][:user_is_jane].description).to eq 'visible only to Jane'
+      end
+
+      it 'adds a deprecation warning' do
+        expect(ActiveSupport::Deprecation).to have_received.warn.with(anything, anything)
       end
     end
   end
@@ -241,6 +247,8 @@ describe Brainstem::Concerns::PresenterDSL do
 
     context "when description is specified in the deprecated format" do
       before do
+        stub(ActiveSupport::Deprecation).warn.with(anything, anything)
+
         presenter_class.fields do
           field :synced_at, :datetime, "Last time the object was synced"
         end
@@ -250,6 +258,10 @@ describe Brainstem::Concerns::PresenterDSL do
         expect(presenter_class.configuration[:fields].keys).to include('synced_at')
         expect(presenter_class.configuration[:fields][:synced_at].type).to eq :datetime
         expect(presenter_class.configuration[:fields][:synced_at].description).to eq 'Last time the object was synced'
+      end
+
+      it 'adds a deprecation warning' do
+        expect(ActiveSupport::Deprecation).to have_received.warn.with(anything, anything)
       end
     end
   end
@@ -299,6 +311,8 @@ describe Brainstem::Concerns::PresenterDSL do
 
     context "when description is specified in the deprecated format" do
       before do
+        stub(ActiveSupport::Deprecation).warn.with(anything, anything)
+
         presenter_class.associations do
           association :something_else, :polymorphic, 'The other things in this Workspace', restrict_to_only: true
         end
@@ -311,6 +325,10 @@ describe Brainstem::Concerns::PresenterDSL do
           info: 'The other things in this Workspace',
           restrict_to_only: true
         )
+      end
+
+      it 'adds a deprecation warning' do
+        expect(ActiveSupport::Deprecation).to have_received.warn.with(anything, anything)
       end
     end
   end

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -6,8 +6,8 @@ require 'brainstem/concerns/presenter_dsl'
 # brainstem_key :projects
 #
 # conditionals do
-#   model   :title_is_hello, lambda { workspace.title == 'hello' }, 'visible when the title is hello'
-#   request :user_is_bob, lambda { current_user.username == 'bob' }, 'visible only to bob'
+#   model   :title_is_hello, lambda { workspace.title == 'hello' }, info: 'visible when the title is hello'
+#   request :user_is_bob, lambda { current_user.username == 'bob' }, info: 'visible only to bob'
 # end
 #
 # fields do
@@ -20,7 +20,8 @@ require 'brainstem/concerns/presenter_dsl'
 #         if: [:user_is_bob, :title_is_hello]
 #
 #   with_options if: :user_is_bob do
-#     field :bob_title, :string, 'another name for the title, only for Bob',
+#     field :bob_title, :string,
+#           info: 'another name for the title, only for Bob',
 #           via: :title
 #   end
 #   fields :nested_permissions do
@@ -30,10 +31,13 @@ require 'brainstem/concerns/presenter_dsl'
 # end
 #
 # associations do
-#   association :tasks, Task, 'The Tasks in this Workspace',
+#   association :tasks, Task,
+#               info: 'The Tasks in this Workspace',
 #               restrict_to_only: true
-#   association :lead_user, User, 'The user who runs this Workspace'
-#   association :subtasks, Task, 'Only Tasks in this Workspace that are subtasks',
+#   association :lead_user, User,
+#               info: 'The user who runs this Workspace'
+#   association :subtasks, Task,
+#               info: 'Only Tasks in this Workspace that are subtasks',
 #               dynamic: lambda { |workspace| workspace.tasks.where('parent_id IS NOT NULL') }
 #   association :something, :polymorphic
 # end
@@ -65,8 +69,8 @@ describe Brainstem::Concerns::PresenterDSL do
   describe 'the conditional block' do
     before do
       presenter_class.conditionals do
-        model      :title_is_hello, lambda { |workspace| workspace.title == 'hello' }, 'visible when the title is hello'
-        request    :user_is_bob, lambda { current_user == 'bob' }, 'visible only to bob'
+        model      :title_is_hello, lambda { |workspace| workspace.title == 'hello' }, info: 'visible when the title is hello'
+        request    :user_is_bob, lambda { current_user == 'bob' }, info: 'visible only to bob'
       end
     end
 
@@ -83,13 +87,28 @@ describe Brainstem::Concerns::PresenterDSL do
     it 'is inherited and overridable' do
       subclass = Class.new(presenter_class)
       subclass.conditionals do
-        model :silly_conditional, lambda { rand > 0.5 }, 'visible half the time'
-        model :title_is_hello, lambda { |workspace| workspace.title == 'HELLO' }, 'visible when the title is hello (in all caps)'
+        model :silly_conditional, lambda { rand > 0.5 }, info: 'visible half the time'
+        model :title_is_hello, lambda { |workspace| workspace.title == 'HELLO' }, info: 'visible when the title is hello (in all caps)'
       end
       expect(presenter_class.configuration[:conditionals].keys).to eq %w[title_is_hello user_is_bob]
       expect(subclass.configuration[:conditionals].keys).to eq %w[title_is_hello user_is_bob silly_conditional]
       expect(presenter_class.configuration[:conditionals][:title_is_hello].description).to eq "visible when the title is hello"
       expect(subclass.configuration[:conditionals][:title_is_hello].description).to eq "visible when the title is hello (in all caps)"
+    end
+
+    context 'when description is specified in the deprecated format' do
+      before do
+        presenter_class.conditionals do
+          model :user_is_jane, lambda { current_user == 'jane' }, 'visible only to Jane'
+        end
+      end
+
+      it 'stores the correct configuration' do
+        expect(presenter_class.configuration[:conditionals].keys).to include('user_is_jane')
+        expect(presenter_class.configuration[:conditionals][:user_is_jane].action).to be_present
+        expect(presenter_class.configuration[:conditionals][:user_is_jane].type).to eq :model
+        expect(presenter_class.configuration[:conditionals][:user_is_jane].description).to eq 'visible only to Jane'
+      end
     end
   end
 
@@ -103,7 +122,8 @@ describe Brainstem::Concerns::PresenterDSL do
               if: [:user_is_bob, :title_is_hello]
 
         with_options if: :user_is_bob do
-          field :bob_title, :string, 'another name for the title, only for Bob',
+          field :bob_title, :string,
+                info: 'another name for the title, only for Bob',
                 via: :title
         end
         fields :nested_permissions do
@@ -125,7 +145,11 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(presenter_class.configuration[:fields][:secret].options).to eq({ via: :secret_info, if: [:user_is_bob, :title_is_hello] })
       expect(presenter_class.configuration[:fields][:bob_title].type).to eq :string
       expect(presenter_class.configuration[:fields][:bob_title].description).to eq 'another name for the title, only for Bob'
-      expect(presenter_class.configuration[:fields][:bob_title].options).to eq({ via: :title, if: [:user_is_bob] })
+      expect(presenter_class.configuration[:fields][:bob_title].options).to eq(
+        via: :title,
+        if: [:user_is_bob],
+        info: 'another name for the title, only for Bob'
+      )
     end
 
     it 'handles nesting' do
@@ -139,7 +163,7 @@ describe Brainstem::Concerns::PresenterDSL do
       subclass.fields do
         field :title, :string
         with_options if: [:some_condition, :some_other_condition] do
-          field :updated_at, :datetime, 'this time I have a description and condition'
+          field :updated_at, :datetime, info: 'this time I have a description and condition'
         end
       end
       expect(presenter_class.configuration[:fields].keys).to match_array %w[updated_at dynamic_title secret bob_title nested_permissions]
@@ -147,24 +171,32 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(presenter_class.configuration[:fields][:updated_at].description).to be_nil
       expect(presenter_class.configuration[:fields][:updated_at].options).to eq({})
       expect(subclass.configuration[:fields][:updated_at].description).to eq 'this time I have a description and condition'
-      expect(subclass.configuration[:fields][:updated_at].options).to eq({ if: [:some_condition, :some_other_condition] })
+      expect(subclass.configuration[:fields][:updated_at].options).to eq(
+        if: [:some_condition, :some_other_condition],
+        info: 'this time I have a description and condition'
+      )
     end
 
     it 'any :if options are combined and inherited using with_options' do
       presenter_class.fields do
         with_options if: :user_is_bob do
-          field :bob_title, :string, 'another name for the title, only for Bob',
-                via: :title, if: :another_condition
-          field :bob_title2, :string, 'another name for the title, only for Bob',
+          field :bob_title, :string,
+                info: 'another name for the title, only for Bob',
+                via: :title,
+                if: :another_condition
+          field :bob_title2, :string,
+                info: 'another name for the title, only for Bob',
                 via: :title, if: :another_condition
         end
       end
       subclass = Class.new(presenter_class)
       subclass.fields do
         with_options if: [:user_is_bob, :more_specific] do
-          field :bob_title, :string, 'another name for the title, only for Bob',
+          field :bob_title, :string,
+                info: 'another name for the title, only for Bob',
                 via: :title, if: [:another_condition]
-          field :bob_title2, :string, 'another name for the title, only for Bob',
+          field :bob_title2, :string,
+                info: 'another name for the title, only for Bob',
                 via: :title
         end
       end
@@ -206,14 +238,30 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(subclass.configuration[:fields][:nested_permissions][:deeper][:something]).to be_present
       expect(subclass.configuration[:fields][:new_nested_permissions]).to be_present
     end
+
+    context "when description is specified in the deprecated format" do
+      before do
+        presenter_class.fields do
+          field :synced_at, :datetime, "Last time the object was synced"
+        end
+      end
+
+      it "stores the correct configuration" do
+        expect(presenter_class.configuration[:fields].keys).to include('synced_at')
+        expect(presenter_class.configuration[:fields][:synced_at].type).to eq :datetime
+        expect(presenter_class.configuration[:fields][:synced_at].description).to eq 'Last time the object was synced'
+      end
+    end
   end
 
   describe 'the associations block' do
     before do
       presenter_class.associations do
-        association :tasks, Task, 'The Tasks in this Workspace',
+        association :tasks, Task,
+                    info: 'The Tasks in this Workspace',
                     restrict_to_only: true
-        association :subtasks, Task, 'Only Tasks in this Workspace that are subtasks',
+        association :subtasks, Task,
+                    info: 'Only Tasks in this Workspace that are subtasks',
                     dynamic: lambda { |workspace| workspace.tasks.where('parent_id IS NOT NULL') }
         association :something, :polymorphic
       end
@@ -223,10 +271,10 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(presenter_class.configuration[:associations].keys).to match_array %w[tasks subtasks something]
       expect(presenter_class.configuration[:associations][:tasks].target_class).to eq Task
       expect(presenter_class.configuration[:associations][:tasks].description).to eq 'The Tasks in this Workspace'
-      expect(presenter_class.configuration[:associations][:tasks].options).to eq({ restrict_to_only: true })
+      expect(presenter_class.configuration[:associations][:tasks].options).to eq({ restrict_to_only: true, info: 'The Tasks in this Workspace' })
       expect(presenter_class.configuration[:associations][:subtasks].target_class).to eq Task
       expect(presenter_class.configuration[:associations][:subtasks].description).to eq 'Only Tasks in this Workspace that are subtasks'
-      expect(presenter_class.configuration[:associations][:subtasks].options.keys).to eq [:dynamic]
+      expect(presenter_class.configuration[:associations][:subtasks].options.keys).to match_array [:dynamic, :info]
       expect(presenter_class.configuration[:associations][:something].target_class).to eq :polymorphic
       expect(presenter_class.configuration[:associations][:something].description).to be_nil
     end
@@ -234,19 +282,36 @@ describe Brainstem::Concerns::PresenterDSL do
     it 'is inherited and overridable' do
       subclass = Class.new(presenter_class)
       subclass.associations do
-        association :tasks, Task, 'The Tasks in this Workspace'
-        association :lead_user, User, 'The user who runs this Workspace'
+        association :tasks, Task, info: 'The Tasks in this Workspace'
+        association :lead_user, User, info: 'The user who runs this Workspace'
       end
 
       expect(presenter_class.configuration[:associations].keys).to match_array %w[tasks subtasks something]
       expect(subclass.configuration[:associations].keys).to match_array %w[tasks subtasks lead_user something]
 
-      expect(presenter_class.configuration[:associations][:tasks].options).to eq({ restrict_to_only: true })
+      expect(presenter_class.configuration[:associations][:tasks].options).to eq({ restrict_to_only: true, info: 'The Tasks in this Workspace' })
       expect(presenter_class.configuration[:associations][:lead_user]).to be_nil
 
-      expect(subclass.configuration[:associations][:tasks].options).to eq({})
+      expect(subclass.configuration[:associations][:tasks].options).to eq({ info: 'The Tasks in this Workspace' })
       expect(subclass.configuration[:associations][:lead_user].target_class).to eq User
       expect(subclass.configuration[:associations][:lead_user].description).to eq 'The user who runs this Workspace'
+    end
+
+    context "when description is specified in the deprecated format" do
+      before do
+        presenter_class.associations do
+          association :something_else, :polymorphic, 'The other things in this Workspace', restrict_to_only: true
+        end
+      end
+
+      it "stores the correct configuration" do
+        expect(presenter_class.configuration[:associations].keys).to include('something_else')
+        expect(presenter_class.configuration[:associations][:something_else].description).to eq 'The other things in this Workspace'
+        expect(presenter_class.configuration[:associations][:something_else].options).to eq(
+          info: 'The other things in this Workspace',
+          restrict_to_only: true
+        )
+      end
     end
   end
 

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -5,8 +5,24 @@ describe Brainstem::DSL::Association do
   let(:name) { :user }
   let(:target_class) { User }
   let(:description) { "This object's user" }
-  let(:options) { { } }
-  let(:association) { Brainstem::DSL::Association.new(name, target_class, description, options) }
+  let(:options) { { info: description } }
+  let(:association) { Brainstem::DSL::Association.new(name, target_class, options) }
+
+  describe 'description' do
+    context 'when `info` is specified in the options' do
+      it 'returns the value specified with the info key' do
+        expect(association.description).to eq(description)
+      end
+    end
+
+    context 'when `info` is not specified in the options' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(association.description).to be_nil
+      end
+    end
+  end
 
   describe "#run_on" do
     let(:context) { { } }

--- a/spec/brainstem/dsl/conditional_spec.rb
+++ b/spec/brainstem/dsl/conditional_spec.rb
@@ -2,8 +2,31 @@ require 'spec_helper'
 require 'brainstem/dsl/conditional'
 
 describe Brainstem::DSL::Conditional do
-  let(:conditional) { Brainstem::DSL::Conditional.new(name, type, action, description) }
+  let(:conditional) { Brainstem::DSL::Conditional.new(name, type, action, options) }
   let(:model) { Workspace.first }
+  let(:options) { { info: description } }
+
+  describe 'description' do
+    let(:name) { :title_is_hello }
+    let(:type) { :model }
+    let(:action) { lambda { |model| model.title == 'hello' } }
+
+    context 'when `info` is specified in the options' do
+      let(:description) { 'visible when the title is hello' }
+
+      it 'returns the value specified with the info key' do
+        expect(conditional.description).to eq(description)
+      end
+    end
+
+    context 'when `info` is not specified in the options' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(conditional.description).to be_nil
+      end
+    end
+  end
 
   describe '.matches?' do
     context 'as a :model conditional' do

--- a/spec/brainstem/dsl/field_spec.rb
+++ b/spec/brainstem/dsl/field_spec.rb
@@ -5,9 +5,25 @@ describe Brainstem::DSL::Field do
   let(:name) { :title }
   let(:type) { :string }
   let(:description) { 'the title of this model' }
-  let(:options) { { } }
-  let(:field) { Brainstem::DSL::Field.new(name, type, description, options) }
+  let(:options) { { info: description } }
+  let(:field) { Brainstem::DSL::Field.new(name, type, options) }
   let(:model) { Workspace.first }
+
+  describe 'description' do
+    context 'when `info` is specified in the options' do
+      it 'returns the value specified with the info key' do
+        expect(field.description).to eq(description)
+      end
+    end
+
+    context 'when `info` is not specified in the options' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(field.description).to be_nil
+      end
+    end
+  end
 
   describe '#method_name' do
     describe 'by default' do

--- a/spec/brainstem/presenter_validator_spec.rb
+++ b/spec/brainstem/presenter_validator_spec.rb
@@ -9,29 +9,34 @@ describe Brainstem::PresenterValidator do
       preload :lead_user
 
       conditionals do
-        model :title_is_hello, lambda { |model| model.title == 'hello' }, 'visible when the title is hello'
-        request :user_is_bob, lambda { current_user == 'bob' }, 'visible only to bob'
+        model :title_is_hello, lambda { |model| model.title == 'hello' }, info: 'visible when the title is hello'
+        request :user_is_bob, lambda { current_user == 'bob' }, info: 'visible only to bob'
       end
 
       fields do
         field :title, :string
         field :description, :string
         field :updated_at, :datetime
-        field :secret, :string, 'a secret, via secret_info',
+        field :secret, :string,
+              info: 'a secret, via secret_info',
               via: :secret_info,
               if: [:user_is_bob, :title_is_hello]
 
         with_options if: :user_is_bob do
-          field :bob_title, :string, 'another name for the title, only for Bob',
+          field :bob_title, :string,
+                info: 'another name for the title, only for Bob',
                 via: :title
         end
       end
 
       associations do
-        association :tasks, Task, 'The Tasks in this Workspace',
+        association :tasks, Task,
+                    info: 'The Tasks in this Workspace',
                     restrict_to_only: true
-        association :lead_user, User, 'The user who runs this Workspace'
-        association :subtasks, Task, 'Only Tasks in this Workspace that are subtasks',
+        association :lead_user, User,
+                    info: 'The user who runs this Workspace'
+        association :subtasks, Task,
+                    info: 'Only Tasks in this Workspace that are subtasks',
                     dynamic: lambda { |workspace| workspace.tasks.where('parent_id IS NOT NULL') }
       end
     end

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -1,4 +1,4 @@
-class WorkspacePresenter < Brainstem::Presenter
+ class WorkspacePresenter < Brainstem::Presenter
   presents Workspace
 
   helper do
@@ -10,8 +10,8 @@ class WorkspacePresenter < Brainstem::Presenter
   preload :lead_user
 
   conditionals do
-    model   :title_is_hello, lambda { |model| model.title == 'hello' }, 'visible when the title is hello'
-    request :user_is_bob, lambda { current_user == 'bob' }, 'visible only to bob'
+    model   :title_is_hello, lambda { |model| model.title == 'hello' }, info: 'visible when the title is hello'
+    request :user_is_bob, lambda { current_user == 'bob' }, info: 'visible only to bob'
   end
 
   fields do
@@ -32,23 +32,26 @@ class WorkspacePresenter < Brainstem::Presenter
       field :access_level, :integer, dynamic: lambda { 2 }
     end
 
-    field :hello_title, :string, 'the title, when hello',
+    field :hello_title, :string,
+          info: 'the title, when hello',
           dynamic: lambda { 'title is hello' },
           if: :title_is_hello
 
-    field :secret, :string, 'a secret, via secret_info',
+    field :secret, :string,
+          info: 'a secret, via secret_info',
           via: :secret_info,
           if: [:user_is_bob, :title_is_hello]
 
     with_options if: :user_is_bob do
-      field :bob_title, :string, 'another name for the title, only for Bob',
+      field :bob_title, :string,
+            info: 'another name for the title, only for Bob',
             via: :title
     end
   end
 
   associations do
-    association :tasks, Task, 'The Tasks in this Workspace'
-    association :lead_user, User, 'The user who runs this Workspace'
+    association :tasks, Task, info: 'The Tasks in this Workspace'
+    association :lead_user, User, info: 'The user who runs this Workspace'
     # association :subtasks, Task, 'Only Tasks in this Workspace that are subtasks',
     #             dynamic: lambda { |workspace| workspace.tasks.where('parent_id IS NOT NULL') },
     #             brainstem_key: 'sub_tasks'
@@ -63,7 +66,7 @@ class CheesePresenter < Brainstem::Presenter
   end
 
   associations do
-    association :user, User, 'The owner of the cheese'
+    association :user, User, info: 'The owner of the cheese'
   end
 end
 
@@ -75,7 +78,7 @@ class GroupPresenter < Brainstem::Presenter
   end
 
   associations do
-    association :tasks, Task, 'The Tasks in this Group'
+    association :tasks, Task, info: 'The Tasks in this Group'
   end
 end
 
@@ -88,10 +91,12 @@ class TaskPresenter < Brainstem::Presenter
 
   associations do
     association :sub_tasks, Task
-    association :other_tasks, Task, 'another copy of the sub_tasks association',
+    association :other_tasks, Task,
+                info: 'another copy of the sub_tasks association',
                 via: :sub_tasks
     association :workspace, Workspace
-    association :restricted, Task, 'only available on only / show requests',
+    association :restricted, Task,
+                info: 'only available on only / show requests',
                 dynamic: lambda { |task| Task.last },
                 restrict_to_only: true
   end
@@ -105,7 +110,8 @@ class UserPresenter < Brainstem::Presenter
   end
 
   associations do
-    association :odd_workspaces, Workspace, 'only the odd numbered workspaces',
+    association :odd_workspaces, Workspace,
+                info: 'only the odd numbered workspaces',
                 dynamic: lambda { |user| user.workspaces.select { |workspace| workspace.id % 2 == 1 } }
   end
 end


### PR DESCRIPTION
#### This branch does the following:
- Allows specifying the description for conditionals, fields and associations with the info option
- Support legacy description param as a string
- Throw a deprecation warning when description param is specified as a string

#### Supported legacy format of conditionals, fields and association:
```
conditionals do
  model   :title_is_hello, lambda { workspace.title == 'hello' }, 'visible when the title is hello'
  request :user_is_bob, lambda { current_user.username == 'bob' }, 'visible only to bob'
end
```
#### Expected format going forward:
```
conditionals do
  model   :title_is_hello, lambda { workspace.title == 'hello' }, info: 'visible when the title is hello'
  request :user_is_bob, lambda { current_user.username == 'bob' }, info: 'visible only to bob'
end
```
