### PR TITLE
Fix Filter and Search

### DIFF
--- a/brainstem.gemspec
+++ b/brainstem.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "yard"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
+  gem.add_development_dependency "db-query-matchers"
 end

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -58,7 +58,7 @@ module Brainstem
         end
       end
 
-      def order_for_search(records, ordered_search_ids, with_models = true)
+      def order_for_search(records, ordered_search_ids, options = {})
         ids_to_position = {}
         ordered_records = []
 
@@ -67,7 +67,7 @@ module Brainstem
         end
 
         records.each do |record|
-          ordered_records[ids_to_position[with_models ? record.id : record ]] = record
+          ordered_records[ids_to_position[options[:with_ids] ? record : record.id]] = record
         end
 
         ordered_records.compact

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -57,6 +57,33 @@ module Brainstem
           end
         end
       end
+
+      def order_for_search(records, ordered_search_ids)
+        ids_to_position = {}
+        ordered_records = []
+
+        ordered_search_ids.each_with_index do |id, index|
+          ids_to_position[id] = index
+        end
+
+        records.each do |record|
+          ordered_records[ids_to_position[record.id]] = record
+        end
+
+        ordered_records.compact
+      end
+
+      def calculate_limit_and_offset
+        if @options[:params][:limit].present? && @options[:params][:offset].present?
+          limit = calculate_limit
+          offset = calculate_offset
+        else
+          limit = calculate_per_page
+          offset = limit * (calculate_page - 1)
+        end
+
+        [limit, offset]
+      end
     end
   end
 end

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -58,7 +58,7 @@ module Brainstem
         end
       end
 
-      def order_for_search(records, ordered_search_ids)
+      def order_for_search(records, ordered_search_ids, with_models = true)
         ids_to_position = {}
         ordered_records = []
 
@@ -67,7 +67,7 @@ module Brainstem
         end
 
         records.each do |record|
-          ordered_records[ids_to_position[record.id]] = record
+          ordered_records[ids_to_position[with_models ? record.id : record ]] = record
         end
 
         ordered_records.compact

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -38,7 +38,8 @@ module Brainstem
 
         result_ids, _ = @options[:primary_presenter].run_search(@options[:params][:search], search_options)
         if result_ids
-          [scope.where(id: result_ids), result_ids]
+          resulting_scope = scope.where(id: result_ids)
+          [resulting_scope, result_ids]
         else
           raise(SearchUnavailableError, 'Search is currently unavailable')
         end

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -39,14 +39,7 @@ module Brainstem
       end
 
       def paginate(scope)
-        if @options[:params][:limit].present? && @options[:params][:offset].present?
-          limit = calculate_limit
-          offset = calculate_offset
-        else
-          limit = calculate_per_page
-          offset = limit * (calculate_page - 1)
-        end
-
+        limit, offset = calculate_limit_and_offset
         scope.limit(limit).offset(offset).distinct
       end
 
@@ -54,30 +47,8 @@ module Brainstem
         @options[:params][:order].present?
       end
 
-      def order_for_search(records, ordered_search_ids)
-        ids_to_position = {}
-        ordered_records = []
-
-        ordered_search_ids.each_with_index do |id, index|
-          ids_to_position[id] = index
-        end
-
-        records.each do |record|
-          ordered_records[ids_to_position[record.id]] = record
-        end
-
-        ordered_records.compact
-      end
-
       def paginate_array(array)
-        if @options[:params][:limit].present? && @options[:params][:offset].present?
-          limit = calculate_limit
-          offset = calculate_offset
-        else
-          limit = calculate_per_page
-          offset = limit * (calculate_page - 1)
-        end
-
+        limit, offset = calculate_limit_and_offset
         array.drop(offset).first(limit) # do we need to uniq this?
       end
     end

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -11,7 +11,7 @@ module Brainstem
           scope = @options[:primary_presenter].apply_ordering_to_scope(scope, @options[:params])
           primary_models = evaluate_scope(scope)
         else
-          primary_models = scope.to_a
+          primary_models = evaluate_scope(scope)
           primary_models = order_for_search(primary_models, ordered_search_ids)
           primary_models = paginate_array(primary_models)
         end

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -2,8 +2,7 @@ module Brainstem
   module QueryStrategies
     class FilterAndSearch < BaseStrategy
       def execute(scope)
-        ordered_search_ids = run_search(scope, filter_includes.map(&:name))
-        scope = scope.where(id: ordered_search_ids)
+        scope, ordered_search_ids = run_search(scope, filter_includes.map(&:name))
         scope = @options[:primary_presenter].apply_filters_to_scope(scope, @options[:params], @options)
         count = scope.count
 
@@ -33,7 +32,7 @@ module Brainstem
 
         result_ids, _ = @options[:primary_presenter].run_search(@options[:params][:search], search_options)
         if result_ids
-          result_ids
+          [scope.where(id: result_ids), result_ids]
         else
           raise(SearchUnavailableError, 'Search is currently unavailable')
         end

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -14,11 +14,17 @@ module Brainstem
           filtered_ids = scope.pluck(:id)
           count = filtered_ids.size
 
-          ordered_ids = order_for_search(filtered_ids, ordered_search_ids, false)
+          # order a potentially large set of ids
+          ordered_ids = order_for_search(filtered_ids, ordered_search_ids, with_ids: true)
           ordered_paginated_ids = paginate_array(ordered_ids)
 
           scope = scope.unscoped.where(id: ordered_paginated_ids)
+          # not using `evaluate_scope` because we are already instantiating
+          # a scope based on ids
           primary_models = scope.to_a
+
+          # Once hydrated, a page worth of models needs to be reordered
+          # due to the `scope.unscoped.where(id: ...` clobbering our ordering
           primary_models = order_for_search(primary_models, ordered_paginated_ids)
         end
 

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -5,10 +5,17 @@ module Brainstem
         ordered_search_ids = run_search(scope, filter_includes.map(&:name))
         scope = scope.where(id: ordered_search_ids)
         scope = @options[:primary_presenter].apply_filters_to_scope(scope, @options[:params], @options)
-        scope = @options[:primary_presenter].apply_ordering_to_scope(scope, @options[:params])
         count = scope.count
-        scope = paginate(scope)
-        primary_models = evaluate_scope(scope)
+
+        if ordering?
+          scope = paginate(scope)
+          scope = @options[:primary_presenter].apply_ordering_to_scope(scope, @options[:params])
+          primary_models = evaluate_scope(scope)
+        else
+          primary_models = scope.to_a
+          primary_models = order_for_search(primary_models, ordered_search_ids)
+          primary_models = paginate_array(primary_models)
+        end
 
         [primary_models, count]
       end
@@ -16,10 +23,8 @@ module Brainstem
       private
 
       def run_search(scope, includes)
-        sort_name, direction = @options[:primary_presenter].calculate_sort_name_and_direction @options[:params]
         search_options = HashWithIndifferentAccess.new(
           include: includes,
-          order: { sort_order: sort_name, direction: direction },
           limit: @options[:default_max_filter_and_search_page],
           offset: 0
         )
@@ -44,6 +49,37 @@ module Brainstem
         end
 
         scope.limit(limit).offset(offset).distinct
+      end
+
+      def ordering?
+        @options[:params][:order].present?
+      end
+
+      def order_for_search(records, ordered_search_ids)
+        ids_to_position = {}
+        ordered_records = []
+
+        ordered_search_ids.each_with_index do |id, index|
+          ids_to_position[id] = index
+        end
+
+        records.each do |record|
+          ordered_records[ids_to_position[record.id]] = record
+        end
+
+        ordered_records.compact
+      end
+
+      def paginate_array(array)
+        if @options[:params][:limit].present? && @options[:params][:offset].present?
+          limit = calculate_limit
+          offset = calculate_offset
+        else
+          limit = calculate_per_page
+          offset = limit * (calculate_page - 1)
+        end
+
+        array.drop(offset).first(limit) # do we need to uniq this?
       end
     end
   end

--- a/lib/brainstem/query_strategies/filter_or_search.rb
+++ b/lib/brainstem/query_strategies/filter_or_search.rb
@@ -68,35 +68,13 @@ module Brainstem
       end
 
       def paginate(scope)
-        if @options[:params][:limit].present? && @options[:params][:offset].present?
-          limit = calculate_limit
-          offset = calculate_offset
-        else
-          limit = calculate_per_page
-          offset = limit * (calculate_page - 1)
-        end
-
+        limit, offset = calculate_limit_and_offset
         [scope.limit(limit).offset(offset).distinct, scope.select("distinct #{scope.connection.quote_table_name @options[:table_name]}.id").count]
       end
 
       def handle_only(scope, only)
         ids = (only || "").split(",").select {|id| id =~ /\A\d+\z/}.uniq
         [scope.where(:id => ids), scope.where(:id => ids).count]
-      end
-
-      def order_for_search(records, ordered_search_ids)
-        ids_to_position = {}
-        ordered_records = []
-
-        ordered_search_ids.each_with_index do |id, index|
-          ids_to_position[id] = index
-        end
-
-        records.each do |record|
-          ordered_records[ids_to_position[record.id]] = record
-        end
-
-        ordered_records.compact
       end
     end
   end

--- a/spec/brainstem/query_strategies/filter_and_search_spec.rb
+++ b/spec/brainstem/query_strategies/filter_and_search_spec.rb
@@ -40,13 +40,40 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
     end
 
     context 'when an order is specified' do
-      let(:params) { default_params.merge({ order: 'id:asc' })}
+      let(:order) { 'id:asc' }
+      let(:params) { default_params.merge({ order: order })}
       let(:expected_ordered_ids) { owned_by_bob.order("cheeses.id ASC").pluck(:id) }
 
       it 'returns the filtered, ordered search results' do
         results, count = run_query
         expect(count).to eq(owned_by_bob.count)
         expect(results.map(&:id)).to eq(expected_ordered_ids)
+      end
+
+      context 'with limit and offset params' do
+        let(:limit) { 2 }
+        let(:offset) { 4 }
+        let(:params) { default_params.merge({ order: order, limit: limit, offset: offset })}
+        let(:expected_paginated_ids) { expected_ordered_ids.drop(offset).first(limit) }
+
+        it 'returns the filtered, ordered, paginated results' do
+          results, count = run_query
+          expect(count).to eq(owned_by_bob.count)
+          expect(results.map(&:id)).to eq(expected_paginated_ids)
+        end
+      end
+
+      context 'with page and per_page params' do
+        let(:page) { 2 }
+        let(:per_page) { 3 }
+        let(:params) { default_params.merge({ order: order, page: page, per_page: per_page })}
+        let(:expected_paginated_ids) { expected_ordered_ids.drop(per_page).first(per_page) }
+
+        it 'returns the filtered, ordered, paginated results' do
+          results, count = run_query
+          expect(count).to eq(owned_by_bob.count)
+          expect(results.map(&:id)).to eq(expected_paginated_ids)
+        end
       end
     end
 
@@ -62,6 +89,32 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
         results, count = run_query
         expect(count).to eq(owned_by_bob.count)
         expect(results.map(&:id)).to eq(expected_ordered_ids)
+      end
+
+      context 'with limit and offset params' do
+        let(:limit) { 2 }
+        let(:offset) { 4 }
+        let(:params) { default_params.merge({ limit: limit, offset: offset })}
+        let(:expected_paginated_ids) { expected_ordered_ids.drop(offset).first(limit) }
+
+        it 'returns the filtered, ordered, paginated results' do
+          results, count = run_query
+          expect(count).to eq(owned_by_bob.count)
+          expect(results.map(&:id)).to eq(expected_paginated_ids)
+        end
+      end
+
+      context 'with page and per_page params' do
+        let(:page) { 2 }
+        let(:per_page) { 3 }
+        let(:params) { default_params.merge({ page: page, per_page: per_page })}
+        let(:expected_paginated_ids) { expected_ordered_ids.drop(per_page).first(per_page) }
+
+        it 'returns the filtered, ordered, paginated results' do
+          results, count = run_query
+          expect(count).to eq(owned_by_bob.count)
+          expect(results.map(&:id)).to eq(expected_paginated_ids)
+        end
       end
     end
   end

--- a/spec/brainstem/query_strategies/filter_and_search_spec.rb
+++ b/spec/brainstem/query_strategies/filter_and_search_spec.rb
@@ -18,6 +18,10 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
     params: params
   } }
 
+  def run_query
+    described_class.new(options).execute(Cheese.all)
+  end
+
   describe '#execute' do
     let(:owned_by_bob) { Cheese.owned_by(bob.id)}
     let(:owned_by_jane) { Cheese.owned_by(jane.id)}
@@ -40,7 +44,7 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
       let(:expected_ordered_ids) { owned_by_bob.order("cheeses.id ASC").pluck(:id) }
 
       it 'returns the filtered, ordered search results' do
-        results, count = described_class.new(options).execute(Cheese.all)
+        results, count = run_query
         expect(count).to eq(owned_by_bob.count)
         expect(results.map(&:id)).to eq(expected_ordered_ids)
       end
@@ -55,7 +59,7 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
       end
 
       it 'returns the filtered results ordered by search' do
-        results, count = described_class.new(options).execute(Cheese.all)
+        results, count = run_query
         expect(count).to eq(owned_by_bob.count)
         expect(results.map(&:id)).to eq(expected_ordered_ids)
       end

--- a/spec/brainstem/query_strategies/filter_and_search_spec.rb
+++ b/spec/brainstem/query_strategies/filter_and_search_spec.rb
@@ -18,21 +18,19 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
     params: params
   } }
 
-  def run_query
-    described_class.new(options).execute(Cheese.all)
-  end
-
   describe '#execute' do
+    def run_query
+      described_class.new(options).execute(Cheese.all)
+    end
+
     let(:owned_by_bob) { Cheese.owned_by(bob.id)}
     let(:owned_by_jane) { Cheese.owned_by(jane.id)}
 
     before do
-      $search_results = Cheese.all.pluck(:id).shuffle
-    end
+      @search_results = search_results = Cheese.all.pluck(:id).shuffle
 
-    before do
-      CheesePresenter.search do |_, _|
-        [$search_results, $search_results.count]
+      CheesePresenter.search do
+        [search_results, search_results.count]
       end
 
       CheesePresenter.filter(:owned_by) { |scope, user_id| scope.owned_by(user_id.to_i) }
@@ -79,7 +77,7 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
 
     context 'when no order is specified' do
       let(:params) { default_params }
-      let(:expected_ordered_ids) { $search_results - owned_by_jane.pluck(:id) }
+      let(:expected_ordered_ids) { @search_results - owned_by_jane.pluck(:id) }
 
       before do
         expect(params[:order]).not_to be_present

--- a/spec/brainstem/query_strategies/filter_and_search_spec.rb
+++ b/spec/brainstem/query_strategies/filter_and_search_spec.rb
@@ -91,6 +91,10 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
         expect(results.map(&:id)).to eq(expected_ordered_ids)
       end
 
+      it 'only does two database queries' do
+        expect { run_query }.to make_database_queries(count: 2)
+      end
+
       context 'with limit and offset params' do
         let(:limit) { 2 }
         let(:offset) { 4 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'sqlite3'
 require 'database_cleaner'
 require 'pry'
 require 'pry-nav'
+require 'db-query-matchers'
 
 require 'brainstem'
 require_relative 'spec_helpers/schema'


### PR DESCRIPTION
Filter And Search was clobbering the order of search results in two places.

Initially it would:
1. Run search and get `ordered_search_ids`
2. Instantiate a scope with `scope.where(id: ordered_search_ids)`
3. Apply filters
4. Apply at least a default ordering
5. Return the models to the frontend

2 and 4 would destroy the order of relevancy that ElasticSearch returned.

This PR determines whether or not the user wants to `order` their search results based on their params. In the case that the user does want order, it imposes that order.

Otherwise, it searches, filters the results, and then reorders them using the `ordered_search_ids`.

Related to https://github.com/mavenlink/mavenlink/pull/9184