### PR TITLE
Add Pagination data to API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
++ **1.1.0 - _12/18/2017_
+  - Add `page_number` key to API responses
+  - Add `page_count` key to API responses
+
 + **1.0.0 - _07/20/2017_
   - Add the capability to generate the documentation extracted from your properly annotated
     presenters and controllers using `bundle exec brainstem generate [ARGS]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
 + **1.1.0 - _12/18/2017_
-  - Add `page_number` key to API responses
-  - Add `page_count` key to API responses
-  - Add `page_size` key to API responses
+  - Add `meta` key to API responses which includes `page_number`, `page_count`, and `page_size` keys.
 
 + **1.0.0 - _07/20/2017_
   - Add the capability to generate the documentation extracted from your properly annotated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 + **1.1.0 - _12/18/2017_
   - Add `page_number` key to API responses
   - Add `page_count` key to API responses
+  - Add `page_size` key to API responses
 
 + **1.0.0 - _07/20/2017_
   - Add the capability to generate the documentation extracted from your properly annotated

--- a/README.md
+++ b/README.md
@@ -216,14 +216,20 @@ Responses will look like the following:
   # Total number of results that matched the query.
   count: 5,
 
-  # Current page returned in the response.
-  page_number: 1,
+  # Information about the request and response.
+  meta: {
+    # Total number of results that matched the query.
+    count: 5,
 
-  # Total number pages available.
-  page_count: 1,
+    # Current page returned in the response.
+    page_number: 1,
 
-  # Number of results per page.
-  page_size: 20,
+    # Total number pages available.
+    page_count: 1,
+
+    # Number of results per page.
+    page_size: 20,
+  },
 
   # A lookup table to top-level keys. Necessary
   # because some objects can have associations of

--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ Responses will look like the following:
   # Total number of results that matched the query.
   count: 5,
 
+  # Current page returned in the response.
+  page_number: 1,
+
+  # Total number pages available.
+  page_count: 1,
+
   # A lookup table to top-level keys. Necessary
   # because some objects can have associations of
   # the same type as themselves. Also helps to

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ Responses will look like the following:
   # Total number pages available.
   page_count: 1,
 
+  # Number of results per page.
+  page_size: 20,
+
   # A lookup table to top-level keys. Necessary
   # because some objects can have associations of
   # the same type as themselves. Also helps to

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -76,11 +76,14 @@ module Brainstem
 
       struct = {
         'count' => count,
-        'page_number' => count > 0 ? options[:params].fetch(:page, 1).to_i : 0,
-        'page_count' => count > 0 ? (count.to_f / page_size).ceil : 0,
-        'page_size' => page_size,
         'results' => [],
         brainstem_key => {},
+        '_meta' => {
+          'count' => count,
+          'page_count' => count > 0 ? (count.to_f / page_size).ceil : 0,
+          'page_number' => count > 0 ? options[:params].fetch(:page, 1).to_i : 0,
+          'page_size' => page_size,
+        }
       }
 
       # Build top-level keys for all requested associations.

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -76,7 +76,7 @@ module Brainstem
 
       struct = {
         'count' => count,
-        'page_number' => count > 0 ? params.fetch(:page, 1) : 0,
+        'page_number' => count > 0 ? params.fetch(:page, 1).to_i : 0,
         'page_count' => count > 0 ? (count.to_f / per_page).ceil : 0,
         'results' => [],
         brainstem_key => {},

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -71,11 +71,13 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
+      page_size = per_page(options[:params])
 
       struct = {
         'count' => count,
         'page_number' => page_number(count, options[:params]),
-        'page_count' => page_count(count, per_page(options[:params])),
+        'page_count' => page_count(count, page_size),
+        'page_size' => page_size,
         'results' => [],
         brainstem_key => {},
       }

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -71,12 +71,11 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
-      per_page = [1, options[:params].fetch(:per_page, default_per_page).to_i].max
 
       struct = {
         'count' => count,
-        'page_number' => count > 0 ? options[:params].fetch(:page, 1).to_i : 0,
-        'page_count' => count > 0 ? (count.to_f / per_page).ceil : 0,
+        'page_number' => page_number(count, options[:params]),
+        'page_count' => page_count(count, per_page(options[:params])),
         'results' => [],
         brainstem_key => {},
       }
@@ -189,6 +188,18 @@ module Brainstem
       if options[:as].present?
         raise "PresenterCollection#presenting no longer accepts the :as option.  Use the brainstem_key annotation in your presenters instead."
       end
+    end
+
+    def page_number(count, params)
+      count > 0 ? params.fetch(:page, 1).to_i : 0
+    end
+
+    def page_count(count, per_page)
+      count > 0 ? (count.to_f / per_page).ceil : 0
+    end
+
+    def per_page(params)
+      [1, params.fetch(:per_page, default_per_page).to_i].max
     end
   end
 end

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -71,8 +71,16 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
+      params = options.fetch(:params, {})
+      per_page = [1, params.fetch(:per_page, default_per_page).to_i].max
 
-      struct = { 'count' => count, brainstem_key => {}, 'results' => [] }
+      struct = {
+        'count' => count,
+        'page_number' => count > 0 ? params.fetch(:page, 1) : 0,
+        'page_count' => count > 0 ? (count.to_f / per_page).ceil : 0,
+        'results' => [],
+        brainstem_key => {},
+      }
 
       # Build top-level keys for all requested associations.
       selected_associations.each do |association|

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -71,7 +71,7 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
-      page_size = per_page(options[:params])
+      page_size = per_page(options)
 
       struct = {
         'count' => count,
@@ -200,8 +200,10 @@ module Brainstem
       count > 0 ? (count.to_f / per_page).ceil : 0
     end
 
-    def per_page(params)
-      [1, params.fetch(:per_page, default_per_page).to_i].max
+    def per_page(options)
+      per_page = [(options[:params][:per_page] || options[:per_page] || default_per_page).to_i, (options[:max_per_page] || default_max_per_page).to_i].min
+      per_page = default_per_page if per_page < 1
+      per_page
     end
   end
 end

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -53,17 +53,18 @@ module Brainstem
       options[:default_max_per_page] = default_max_per_page
       options[:default_max_filter_and_search_page] = default_max_filter_and_search_page
 
-      primary_models, count = strategy(options, scope).execute(scope)
+      strategy = get_strategy(options, scope)
+      primary_models, count = strategy.execute(scope)
 
       # Determine if an exception should be raised on an empty result set.
       if options[:raise_on_empty] && primary_models.empty?
         raise options[:empty_error_class] || ActiveRecord::RecordNotFound
       end
 
-      structure_response(presented_class, primary_models, count, options)
+      structure_response(presented_class, primary_models, strategy, count, options)
     end
 
-    def structure_response(presented_class, primary_models, count, options)
+    def structure_response(presented_class, primary_models, strategy, count, options)
       # key these models will use in the struct that is output
       brainstem_key = brainstem_key_for!(presented_class)
 
@@ -71,7 +72,7 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
-      page_size = calculate_per_page(options)
+      page_size = strategy.calculate_per_page
 
       struct = {
         'count' => count,
@@ -153,7 +154,7 @@ module Brainstem
 
     private
 
-    def strategy(options, scope)
+    def get_strategy(options, scope)
       strat = options[:primary_presenter].get_query_strategy
 
       return Brainstem::QueryStrategies::FilterAndSearch.new(options) if strat == :filter_and_search && searching?(options)
@@ -190,12 +191,6 @@ module Brainstem
       if options[:as].present?
         raise "PresenterCollection#presenting no longer accepts the :as option.  Use the brainstem_key annotation in your presenters instead."
       end
-    end
-
-    def calculate_per_page(options)
-      per_page = [(options[:params][:per_page] || options[:per_page] || default_per_page).to_i, (options[:max_per_page] || default_max_per_page).to_i].min
-      per_page = default_per_page if per_page < 1
-      per_page
     end
   end
 end

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -75,8 +75,8 @@ module Brainstem
 
       struct = {
         'count' => count,
-        'page_number' => page_number(count, options[:params]),
-        'page_count' => page_count(count, page_size),
+        'page_number' => count > 0 ? options[:params].fetch(:page, 1).to_i : 0,
+        'page_count' => count > 0 ? (count.to_f / page_size).ceil : 0,
         'page_size' => page_size,
         'results' => [],
         brainstem_key => {},
@@ -190,14 +190,6 @@ module Brainstem
       if options[:as].present?
         raise "PresenterCollection#presenting no longer accepts the :as option.  Use the brainstem_key annotation in your presenters instead."
       end
-    end
-
-    def page_number(count, params)
-      count > 0 ? params.fetch(:page, 1).to_i : 0
-    end
-
-    def page_count(count, per_page)
-      count > 0 ? (count.to_f / per_page).ceil : 0
     end
 
     def per_page(options)

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -71,7 +71,7 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
-      page_size = per_page(options)
+      page_size = calculate_per_page(options)
 
       struct = {
         'count' => count,
@@ -192,7 +192,7 @@ module Brainstem
       end
     end
 
-    def per_page(options)
+    def calculate_per_page(options)
       per_page = [(options[:params][:per_page] || options[:per_page] || default_per_page).to_i, (options[:max_per_page] || default_max_per_page).to_i].min
       per_page = default_per_page if per_page < 1
       per_page

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -71,12 +71,11 @@ module Brainstem
       selected_associations = filter_includes(options)
 
       optional_fields = filter_optional_fields(options)
-      params = options.fetch(:params, {})
-      per_page = [1, params.fetch(:per_page, default_per_page).to_i].max
+      per_page = [1, options[:params].fetch(:per_page, default_per_page).to_i].max
 
       struct = {
         'count' => count,
-        'page_number' => count > 0 ? params.fetch(:page, 1).to_i : 0,
+        'page_number' => count > 0 ? options[:params].fetch(:page, 1).to_i : 0,
         'page_count' => count > 0 ? (count.to_f / per_page).ceil : 0,
         'results' => [],
         brainstem_key => {},

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -78,7 +78,7 @@ module Brainstem
         'count' => count,
         'results' => [],
         brainstem_key => {},
-        '_meta' => {
+        'meta' => {
           'count' => count,
           'page_count' => count > 0 ? (count.to_f / page_size).ceil : 0,
           'page_number' => count > 0 ? options[:params].fetch(:page, 1).to_i : 0,

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -26,6 +26,12 @@ module Brainstem
         end
       end
 
+      def calculate_per_page
+        per_page = [(@options[:params][:per_page] || @options[:per_page] || @options[:default_per_page]).to_i, (@options[:max_per_page] || @options[:default_max_per_page]).to_i].min
+        per_page = @options[:default_per_page] if per_page < 1
+        per_page
+      end
+
       private
 
       def calculate_limit
@@ -34,12 +40,6 @@ module Brainstem
 
       def calculate_offset
         [@options[:params][:offset].to_i, 0].max
-      end
-
-      def calculate_per_page
-        per_page = [(@options[:params][:per_page] || @options[:per_page] || @options[:default_per_page]).to_i, (@options[:max_per_page] || @options[:default_max_per_page]).to_i].min
-        per_page = @options[:default_per_page] if per_page < 1
-        per_page
       end
 
       def calculate_page

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -1154,7 +1154,8 @@ describe Brainstem::PresenterCollection do
 
   describe '#structure_response' do
     let(:options) { {params: {}, primary_presenter: @presenter_collection.for!(Workspace) } }
-    let(:response_body) { @presenter_collection.structure_response(Workspace, Workspace.all, 17, options) }
+    let(:response_body) { @presenter_collection.structure_response(Workspace, Workspace.all, strategy, 17, options) }
+    let(:strategy) { OpenStruct.new(calculate_per_page: 25) }
 
     it 'has a count' do
       expect(response_body['count']).to eq(17)

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -201,28 +201,10 @@ describe Brainstem::PresenterCollection do
         end
 
         describe "page_size" do
-          [
-            # per_page  default_per_page  max_per_page  default_max_per_page  expected   message
-            [       10,               20,          100,                  200,       10,  "per page < max"],
-            [      nil,               20,          100,                  200,       20,  "no per page and default < max"],
-            [      nil,              200,          100,                  200,      100,  "no per page and default > max"],
-            [      150,               20,          100,                  200,      100,  "per page > max"],
-            [      150,               20,          nil,                  200,      150,  "no max and per page < default max"],
-            [      250,               20,          nil,                  200,      200,  "no max and per page > default max"],
-          ].each do |per_page, default_per_page, max_per_page, default_max_per_page, expected, message|
-            describe "for foo" do
-              let(:params) { { per_page: per_page } }
-              let(:max_per_page) { max_per_page }
+          let(:params) { {} }
 
-              before do
-                @presenter_collection.default_per_page = default_per_page
-                @presenter_collection.default_max_per_page = default_max_per_page
-              end
-
-              it "handles '#{message}'" do
-                expect(result["page_size"]).to eq(expected)
-              end
-            end
+          it "calculates the correct page size" do
+            expect(result["page_count"]).to eq(3)
           end
         end
       end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -161,7 +161,6 @@ describe Brainstem::PresenterCollection do
       end
 
       describe "pagination keys" do
-        # let(:record_count) { Workspace.unscoped.count }
         let(:result) { @presenter_collection.presenting("workspaces", params: params) { Workspace.unscoped } }
 
         describe "page_number" do

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -162,7 +162,7 @@ describe Brainstem::PresenterCollection do
 
       describe "meta keys" do
         let(:max_per_page) { nil }
-        let(:meta_keys) { result["_meta"] }
+        let(:meta_keys) { result["meta"] }
         let(:result) { @presenter_collection.presenting("workspaces", params: params, max_per_page: max_per_page) { Workspace.unscoped } }
 
         describe "count" do
@@ -314,7 +314,7 @@ describe Brainstem::PresenterCollection do
     describe "the 'results' top level key" do
       it "comes back with an explicit list of the matching results" do
         structure = @presenter_collection.presenting("workspaces", :params => { :include => "tasks" }, :max_per_page => 2) { Workspace.where(:id => 1) }
-        expect(structure.keys).to match_array %w[workspaces tasks count results _meta]
+        expect(structure.keys).to match_array %w[workspaces tasks count results meta]
         expect(structure['results']).to eq(Workspace.where(:id => 1).limit(2).map {|w| { 'key' => 'workspaces', 'id' => w.id.to_s } })
         expect(structure['workspaces'].keys).to eq(%w[1])
       end
@@ -323,10 +323,10 @@ describe Brainstem::PresenterCollection do
     describe "includes" do
       it "reads allowed includes from the presenter" do
         result = @presenter_collection.presenting("workspaces", :params => { :include => "drop table,tasks,users" }) { Workspace.unscoped }
-        expect(result.keys).to match_array %w[count _meta workspaces tasks results]
+        expect(result.keys).to match_array %w[count meta workspaces tasks results]
 
         result = @presenter_collection.presenting("workspaces", :params => { :include => "foo,tasks,lead_user" }) { Workspace.unscoped }
-        expect(result.keys).to match_array %w[count _meta workspaces tasks users results]
+        expect(result.keys).to match_array %w[count meta workspaces tasks users results]
       end
 
       it "defaults to not include any allowed includes" do
@@ -362,7 +362,7 @@ describe Brainstem::PresenterCollection do
         result = @presenter_collection.presenting("tasks", :params => { :include => "workspace" }, :max_per_page => 2) { Task.where(:id => t.id) }
         expect(result['tasks'].keys).to eq([ t.id.to_s ])
         expect(result['workspaces']).to eq({})
-        expect(result.keys).to match_array %w[tasks workspaces count _meta results]
+        expect(result.keys).to match_array %w[tasks workspaces count meta results]
       end
 
       context 'when including something of the same type as the primary model' do
@@ -969,7 +969,7 @@ describe Brainstem::PresenterCollection do
       context "when there is no sort provided" do
         it "returns an empty array when there are no objects" do
           result = @presenter_collection.presenting("workspaces") { Workspace.where(:id => nil) }
-          expect(result).to eq('count' => 0, '_meta' => { 'count' => 0, 'page_count' => 0, 'page_number' => 0, 'page_size' => 20 }, 'workspaces' => {}, 'results' => [])
+          expect(result).to eq('count' => 0, 'meta' => { 'count' => 0, 'page_count' => 0, 'page_number' => 0, 'page_size' => 20 }, 'workspaces' => {}, 'results' => [])
         end
 
         it "falls back to the object's sort order when nothing is provided" do
@@ -1024,7 +1024,7 @@ describe Brainstem::PresenterCollection do
 
         result = @presenter_collection.presenting("workspaces", :params => { :order => "description:drop table" }) { Workspace.where("id is not null") }
         expect(last_direction).to eq('asc')
-        expect(result.keys).to match_array %w[count _meta workspaces results]
+        expect(result.keys).to match_array %w[count meta workspaces results]
 
         result = @presenter_collection.presenting("workspaces", :params => { :order => "description:;;hacker;;" }) { Workspace.where("id is not null") }
         expect(last_direction).to eq('asc')

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -10,7 +10,7 @@ describe Brainstem::PresenterCollection do
   let(:jane) { User.where(:username => "jane").first }
 
   describe "#presenting" do
-    describe "#pagination" do
+    describe "pagination" do
       before do
         @presenter_collection.default_per_page = 2
         @presenter_collection.default_max_per_page = 3

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -159,6 +159,47 @@ describe Brainstem::PresenterCollection do
           expect(result['count']).to eq(Workspace.count)
         end
       end
+
+      describe "pagination keys" do
+        # let(:record_count) { Workspace.unscoped.count }
+        let(:result) { @presenter_collection.presenting("workspaces", params: params) { Workspace.unscoped } }
+
+        describe "page_number" do
+          describe "when page is provided" do
+            let(:params) { { page: 2 } }
+
+            it "indicates the provided page" do
+              expect(result["page_number"]).to eq(2)
+            end
+          end
+
+          describe "when page is not profided" do
+            let(:params) { {} }
+
+            it "indicates the first page" do
+              expect(result["page_number"]).to eq(1)
+            end
+          end
+        end
+
+        describe "page_count" do
+          describe "when per_page is provided" do
+            let(:params) { { per_page: 4 } }
+
+            it "calculates the correct page count" do
+              expect(result["page_count"]).to eq(2)
+            end
+          end
+
+          describe "when per_page is not provided" do
+            let(:params) { {} }
+
+            it "calculates the correct page count based on the default page size" do
+              expect(result["page_count"]).to eq(3)
+            end
+          end
+        end
+      end
     end
 
     describe 'strategies' do
@@ -256,7 +297,7 @@ describe Brainstem::PresenterCollection do
     describe "the 'results' top level key" do
       it "comes back with an explicit list of the matching results" do
         structure = @presenter_collection.presenting("workspaces", :params => { :include => "tasks" }, :max_per_page => 2) { Workspace.where(:id => 1) }
-        expect(structure.keys).to match_array %w[workspaces tasks count results]
+        expect(structure.keys).to match_array %w[workspaces tasks count page_number page_count results]
         expect(structure['results']).to eq(Workspace.where(:id => 1).limit(2).map {|w| { 'key' => 'workspaces', 'id' => w.id.to_s } })
         expect(structure['workspaces'].keys).to eq(%w[1])
       end
@@ -265,10 +306,10 @@ describe Brainstem::PresenterCollection do
     describe "includes" do
       it "reads allowed includes from the presenter" do
         result = @presenter_collection.presenting("workspaces", :params => { :include => "drop table,tasks,users" }) { Workspace.unscoped }
-        expect(result.keys).to match_array %w[count workspaces tasks results]
+        expect(result.keys).to match_array %w[count page_count page_number workspaces tasks results]
 
         result = @presenter_collection.presenting("workspaces", :params => { :include => "foo,tasks,lead_user" }) { Workspace.unscoped }
-        expect(result.keys).to match_array %w[count workspaces tasks users results]
+        expect(result.keys).to match_array %w[count page_count page_number workspaces tasks users results]
       end
 
       it "defaults to not include any allowed includes" do
@@ -304,7 +345,7 @@ describe Brainstem::PresenterCollection do
         result = @presenter_collection.presenting("tasks", :params => { :include => "workspace" }, :max_per_page => 2) { Task.where(:id => t.id) }
         expect(result['tasks'].keys).to eq([ t.id.to_s ])
         expect(result['workspaces']).to eq({})
-        expect(result.keys).to match_array %w[tasks workspaces count results]
+        expect(result.keys).to match_array %w[tasks workspaces count page_count page_number results]
       end
 
       context 'when including something of the same type as the primary model' do
@@ -911,7 +952,7 @@ describe Brainstem::PresenterCollection do
       context "when there is no sort provided" do
         it "returns an empty array when there are no objects" do
           result = @presenter_collection.presenting("workspaces") { Workspace.where(:id => nil) }
-          expect(result).to eq('count' => 0, 'workspaces' => {}, 'results' => [])
+          expect(result).to eq('count' => 0, 'page_count' => 0, 'page_number' => 0, 'workspaces' => {}, 'results' => [])
         end
 
         it "falls back to the object's sort order when nothing is provided" do
@@ -966,7 +1007,7 @@ describe Brainstem::PresenterCollection do
 
         result = @presenter_collection.presenting("workspaces", :params => { :order => "description:drop table" }) { Workspace.where("id is not null") }
         expect(last_direction).to eq('asc')
-        expect(result.keys).to match_array %w[count workspaces results]
+        expect(result.keys).to match_array %w[count page_count page_number workspaces results]
 
         result = @presenter_collection.presenting("workspaces", :params => { :order => "description:;;hacker;;" }) { Workspace.where("id is not null") }
         expect(last_direction).to eq('asc')

--- a/spec/brainstem/query_strategies/filter_and_search_spec.rb
+++ b/spec/brainstem/query_strategies/filter_and_search_spec.rb
@@ -18,6 +18,8 @@ describe Brainstem::QueryStrategies::FilterAndSearch do
     params: params
   } }
 
+  it_behaves_like Brainstem::QueryStrategies::BaseStrategy
+
   describe '#execute' do
     def run_query
       described_class.new(options).execute(Cheese.all)

--- a/spec/brainstem/query_strategies/filter_or_search_spec.rb
+++ b/spec/brainstem/query_strategies/filter_or_search_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 # The functionality of this is mainly tested in more integration-y tests in presenter_collection_spec.rb
 
 describe Brainstem::QueryStrategies::FilterOrSearch do
+  it_behaves_like Brainstem::QueryStrategies::BaseStrategy
+
   describe '#execute' do
     context 'we are searching' do
       let(:subject) { described_class.new(@options) }

--- a/spec/shared/base_strategy.rb
+++ b/spec/shared/base_strategy.rb
@@ -7,15 +7,15 @@ shared_examples_for Brainstem::QueryStrategies::BaseStrategy do
     let(:result) { strategy.calculate_per_page }
 
     [
-      # per_page  default_per_page  max_per_page  default_max_per_page  expected   message
-      [       10,               20,          100,                  200,       10,  "per page < max"],
-      [      nil,               20,          100,                  200,       20,  "no per page and default < max"],
-      [      nil,              200,          100,                  200,      100,  "no per page and default > max"],
-      [      150,               20,          100,                  200,      100,  "per page > max"],
-      [      150,               20,          nil,                  200,      150,  "no max and per page < default max"],
-      [      250,               20,          nil,                  200,      200,  "no max and per page > default max"],
-    ].each do |per_page, default_per_page, max_per_page, default_max_per_page, expected, message|
-      describe "for '#{message}'" do
+      # per_page  default_per_page  max_per_page  default_max_per_page  expected   situation                             used
+      [       10,               20,          100,                  200,       10,  "per page < max",                     "the per page"],
+      [      nil,               20,          100,                  200,       20,  "no per page and default < max",      "the default"],
+      [      nil,              200,          100,                  200,      100,  "no per page and default > max",      "the max"],
+      [      150,               20,          100,                  200,      100,  "per page > max",                     "the max"],
+      [      150,               20,          nil,                  200,      150,  "no max and per page < default max",  "the per page"],
+      [      250,               20,          nil,                  200,      200,  "no max and per page > default max",  "the default max"],
+    ].each do |per_page, default_per_page, max_per_page, default_max_per_page, expected, situation, used|
+      describe "when #{situation}" do
         let(:options) {
           {
             params: {
@@ -27,7 +27,7 @@ shared_examples_for Brainstem::QueryStrategies::BaseStrategy do
           }
         }
 
-        it "calculates the expected result'" do
+        it "uses #{used}" do
           expect(result).to eq(expected)
         end
       end

--- a/spec/shared/base_strategy.rb
+++ b/spec/shared/base_strategy.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+shared_examples_for Brainstem::QueryStrategies::BaseStrategy do
+  let(:strategy) { described_class.new(options) }
+
+  describe "#calculate_per_page" do
+    let(:result) { strategy.calculate_per_page }
+
+    [
+      # per_page  default_per_page  max_per_page  default_max_per_page  expected   message
+      [       10,               20,          100,                  200,       10,  "per page < max"],
+      [      nil,               20,          100,                  200,       20,  "no per page and default < max"],
+      [      nil,              200,          100,                  200,      100,  "no per page and default > max"],
+      [      150,               20,          100,                  200,      100,  "per page > max"],
+      [      150,               20,          nil,                  200,      150,  "no max and per page < default max"],
+      [      250,               20,          nil,                  200,      200,  "no max and per page > default max"],
+    ].each do |per_page, default_per_page, max_per_page, default_max_per_page, expected, message|
+      describe "for '#{message}'" do
+        let(:options) {
+          {
+            params: {
+              per_page: per_page,
+            },
+            default_per_page: default_per_page,
+            default_max_per_page: default_max_per_page,
+            max_per_page: max_per_page,
+          }
+        }
+
+        it "calculates the expected result'" do
+          expect(result).to eq(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
RFC -> https://github.com/mavenlink/rfc/pull/28
Bigmaven PR -> https://github.com/mavenlink/mavenlink/pull/10740
Brainstem-js PR -> https://github.com/mavenlink/brainstem-js/pull/121
Brainstem-redux PR -> https://github.com/mavenlink/brainstem-redux/pull/55

Adds pagination information to API responses. Currently deciding between doing this or calculating this client-side. Client-side calculations are doable, but require holding on to some state (what `perPage` and `page` the requests were made with).