### PR TITLE
Add support for specifying type, item type and required options for Controller / Presenter fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
++ **1.1.2** - _02/14/2018_
+  - Added support for indicating an endpoint param is required with the `required` key in the options hash.
+  ```
+        params.valid :message,
+          info: "the message of the post",
+          required: true
+  ```
+  - Added support for specifying the type of an endpoint param with the `type` key in the options hash. For endpoint params
+  that are an Array, type of list items can be specified using `item` key in the options hash. 
+  ```
+        params.valid :viewable_by,
+          type: "array",
+          item: "integer",
+          info: "an array of user ids that can access the post"
+  ```
+  - Added support for generating markdown documentation with the `required`, `type` and `item` keys in the options hash for an endpoint param.
+
 + **1.1.1** - _01/15/2017_
   - Add `Brainstem.mysql_use_calc_found_rows` boolean config option to utilize MySQL's [FOUND_ROWS()](https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_found-rows) functionality to avoid issuing a new query to calculate the record count, which has the potential to up to double the response time of the endpoint.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,21 @@
 # Changelog
 
-+ **1.1.2** - _02/14/2018_
-  - Added support for indicating an endpoint param is required with the `required` key in the options hash.
++ **1.2.0** - _02/14/2018_
+  - Add the capability to indicate an endpoint param is required with the `required` key in the options hash.
   ```
-        params.valid :message,
-          info: "the message of the post",
-          required: true
+        params.valid :message, :text,
+          required: true,
+          info: "the message of the post"
   ```
-  - Added support for specifying the type of an endpoint param with the `type` key in the options hash. For endpoint params
-  that are an Array, type of list items can be specified using `item` key in the options hash. 
+  - Add support for specifying the type of an endpoint param. For an endpoint param that has type `Array`,
+  type of list items can be specified using `item_type` key in the options hash. 
   ```
-        params.valid :viewable_by,
-          type: "array",
-          item: "integer",
+        params.valid :viewable_by, :array,
+          item_type: :integer,
           info: "an array of user ids that can access the post"
   ```
-  - Added support for generating markdown documentation with the `required`, `type` and `item` keys in the options hash for an endpoint param.
+  - Include the type and item type when generating markdown documentation for endpoint params.  
+  - Add support for generating markdown documentation when the `required` option is specified on an endpoint param.
 
 + **1.1.1** - _01/15/2017_
   - Add `Brainstem.mysql_use_calc_found_rows` boolean config option to utilize MySQL's [FOUND_ROWS()](https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_found-rows) functionality to avoid issuing a new query to calculate the record count, which has the potential to up to double the response time of the endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@
           info: "the message of the post"
   ```
   - Add support for specifying the type of an endpoint param. For an endpoint param that has type `Array`,
-  type of list items can be specified using `item_type` key in the options hash. 
+    type of list items can be specified using `item_type` key in the options hash.
   ```
         params.valid :viewable_by, :array,
           item_type: :integer,
+          info: "an array of user ids that can access the post"
+  ```
+  - Add support for specifying the data type of an item for a presenter field using `item_type` key in the
+    options hash when the field is of type `Array`.
+  ```
+        field :aliases, :array,
+          item_type: :string,
           info: "an array of user ids that can access the post"
   ```
   - Include the type and item type when generating markdown documentation for endpoint params.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,22 @@
   - Add the capability to indicate an endpoint param is required with the `required` key in the options hash.
   ```
         params.valid :message, :text,
-          required: true,
-          info: "the message of the post"
+                     required: true,
+                     info: "the message of the post"
   ```
   - Add support for specifying the type of an endpoint param. For an endpoint param that has type `Array`,
     type of list items can be specified using `item_type` key in the options hash.
   ```
         params.valid :viewable_by, :array,
-          item_type: :integer,
-          info: "an array of user ids that can access the post"
+                     item_type: :integer,
+                     info: "an array of user ids that can access the post"
   ```
   - Add support for specifying the data type of an item for a presenter field using `item_type` key in the
     options hash when the field is of type `Array`.
   ```
         field :aliases, :array,
-          item_type: :string,
-          info: "an array of user ids that can access the post"
+              item_type: :string,
+              info: "an array of user ids that can access the post"
   ```
   - Include the type and item type when generating markdown documentation for endpoint params.  
   - Add support for generating markdown documentation when the `required` option is specified on an endpoint param.

--- a/README.md
+++ b/README.md
@@ -505,16 +505,18 @@ context, and it will keep the documentation isolated to that specific action:
 ```ruby
 brainstem_params do
   valid :global_controller_param, :string,
-    info: "A trivial example of a param that applies to all actions."
+                                  info: "A trivial example of a param that applies to all actions."
 
   actions :index do
     # This adds a `blog_id` param to just the `index` action.
-    valid :blog_id, :integer, info: "The id of the blog to which this post belongs"
+    valid :blog_id, :integer,
+          info: "The id of the blog to which this post belongs"
   end
 
   actions :create, :update do
     # This will add an `id` param to both `create` and `update` actions.
-    valid :id, :integer, info: "The id of the blog post"
+    valid :id, :integer,
+          info: "The id of the blog post"
   end
 end
 ```
@@ -590,19 +592,21 @@ class BlogPostsController < ApiController
   brainstem_params do
 
     # Add an `:category_id` param to all actions in this controller / children:
-    valid :category_id, :integer, info: "(required) the category's ID"
+    valid :category_id, :integer,
+          info: "(required) the category's ID"
 
     # Do not document this additional field.
     valid :lang, :string,
-      info: "(optional) the language of the requested post",
-      nodoc: true
+          info: "(optional) the language of the requested post",
+          nodoc: true
 
 
     actions :show do
       # Declare a nested param under the `brainstem_model_name` root key,
       # i.e. `params[:blog_post][:id]`):
       model_params do |post|
-        post.valid :id, :integer, info: "the id of the post", required: true
+        post.valid :id, :integer,
+                   info: "the id of the post", required: true
       end
     end
 
@@ -610,12 +614,12 @@ class BlogPostsController < ApiController
     actions :create do
       model_params :post do |params|
         params.valid :message, :string,
-          info: "the id of the post",
-          required: true
+                     info: "the id of the post",
+                     required: true
 
         params.valid :viewable_by, :array,          
-          item_type: :integer,
-          info: "an array of user ids that can access the post"
+                     item_type: :integer,
+                     info: "an array of user ids that can access the post"
       end
     end
 
@@ -979,12 +983,12 @@ the `lookup` will be used.
   ```ruby
   associations do
     association :current_user_groups, Group,
-      info: "the Groups for the current user",
-      lookup: lambda { |models|
-        Group.where(subject_id: models.map(&:id)
-          .where(user_id: current_user.id)
-          .group_by { |group| group.subject_id }
-      }
+                info: "the Groups for the current user",
+                lookup: lambda { |models|
+                  Group.where(subject_id: models.map(&:id)
+                    .where(user_id: current_user.id)
+                    .group_by { |group| group.subject_id }
+                }
   end
   ```
 
@@ -996,15 +1000,15 @@ the `lookup` will be used.
   ```ruby
   fields do
     field :current_user_post_count, Post,
-      info: "count of Posts the current_user has for this model",
-      lookup: lambda { |models|
-        lookup = Post.where(subject_id: models.map(&:id)
-          .where(user_id: current_user.id)
-          .group_by { |post| post.subject_id }
+          info: "count of Posts the current_user has for this model",
+          lookup: lambda { |models|
+            lookup = Post.where(subject_id: models.map(&:id)
+              .where(user_id: current_user.id)
+              .group_by { |post| post.subject_id }
 
-        lookup
-       },
-       lookup_fetch: lambda { |lookup, model| lookup[model.id] }
+            lookup
+          },
+          lookup_fetch: lambda { |lookup, model| lookup[model.id] }
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -582,13 +582,30 @@ class BlogPostsController < ApiController
       info: "(optional) the language of the requested post",
       nodoc: true
 
+
     actions :show do
       # Declare a nested param under the `brainstem_model_name` root key,
       # i.e. `params[:blog_post][:id]`):
       model_params do |post|
-        post.valid :id, info: "(required) the id of the post"
+        post.valid :id, info: "the id of the post", required: true
       end
     end
+
+
+    actions :create do
+      model_params :post do |params|
+        params.valid :message,
+          type: "string",
+          info: "the id of the post",
+          required: true
+
+        params.valid :viewable_by,
+          type: "array",
+          item: "integer",
+          info: "an array of user ids that can access the post"
+      end
+    end
+
 
     actions :share do
       # Declare a nested param with an explicit root key:, i.e. `params[:share][...]`

--- a/README.md
+++ b/README.md
@@ -66,11 +66,21 @@ module Api
 
       # Specify the fields to be present in the returned JSON.
       fields do
-        field :name, :string, info: "the Widget's name"
-        field :legacy, :boolean, info: "true for legacy Widgets, false otherwise", via: :legacy?
-        field :longform_description, :string, info: "feature-length description of this Widget", optional: true
-        field :updated_at, :datetime, info: "the time of this Widget's last update"
-        field :created_at, :datetime, info: "the time at which this Widget was created"
+        field :name, :string,
+              info: "the Widget's name"
+        field :legacy, :boolean,
+              info: "true for legacy Widgets, false otherwise",
+              via: :legacy?
+        field :longform_description, :string,
+              info: "feature-length description of this Widget",
+              optional: true
+        field :aliases, :array,
+              item_type: :string,
+              info: "the differnt aliases for the widget"
+        field :updated_at, :datetime,
+              info: "the time of this Widget's last update"
+        field :created_at, :datetime,
+              info: "the time at which this Widget was created"
       end
 
       # Associations can be included by providing include=association_name in the URL.
@@ -78,8 +88,10 @@ module Api
       # columns on the model, otherwise the user must explicitly request associations
       # to avoid unnecessary loads.
       associations do
-        association :features, Feature, info: "features associated with this Widget"
-        association :location, Location, info: "the location of this Widget"
+        association :features, Feature,
+                    info: "features associated with this Widget"
+        association :location, Location,
+                    info: "the location of this Widget"
       end
     end
   end
@@ -447,11 +459,14 @@ class PostsPresenter < Brainstem::Presenter
   MARKDOWN
 
   associations do
-    association :author, User, info: "the author of the post"
+    association :author, User,
+                info: "the author of the post"
 
     # Temporarily disable documenting this relationship as we revamp the
     # editorial system:
-    association :editor, User, info: "the editor of the post", nodoc: true
+    association :editor, User,
+                info: "the editor of the post",
+                nodoc: true
   end
 end
 ```
@@ -907,6 +922,9 @@ Brainstem provides a rich DSL for building presenters.  This section details the
     field :dynamic_name, :string,
           info: "a formatted name for this Widget",
           dynamic: lambda { |widget| "This Widget's name is #{widget.name}" }
+    field :aliases, :array,
+          item_type: :string,
+          info: "the differnt aliases for the widget"
     field :longform_description, :string,
           info: "feature-length description of this Widget",
           optional: true

--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ context, and it will keep the documentation isolated to that specific action:
 ```ruby
 brainstem_params do
   valid :global_controller_param, :string,
-                                  info: "A trivial example of a param that applies to all actions."
+        info: "A trivial example of a param that applies to all actions."
 
   actions :index do
     # This adds a `blog_id` param to just the `index` action.

--- a/README.md
+++ b/README.md
@@ -489,17 +489,17 @@ context, and it will keep the documentation isolated to that specific action:
 
 ```ruby
 brainstem_params do
-  valid :global_controller_param,
+  valid :global_controller_param, :string,
     info: "A trivial example of a param that applies to all actions."
 
   actions :index do
     # This adds a `blog_id` param to just the `index` action.
-    valid :blog_id, info: "The id of the blog to which this post belongs"
+    valid :blog_id, :integer, info: "The id of the blog to which this post belongs"
   end
 
   actions :create, :update do
     # This will add an `id` param to both `create` and `update` actions.
-    valid :id, info: "The id of the blog post"
+    valid :id, :integer, info: "The id of the blog post"
   end
 end
 ```
@@ -575,10 +575,10 @@ class BlogPostsController < ApiController
   brainstem_params do
 
     # Add an `:category_id` param to all actions in this controller / children:
-    valid :category_id, info: "(required) the category's ID"
+    valid :category_id, :integer, info: "(required) the category's ID"
 
     # Do not document this additional field.
-    valid :lang,
+    valid :lang, :string,
       info: "(optional) the language of the requested post",
       nodoc: true
 
@@ -587,21 +587,19 @@ class BlogPostsController < ApiController
       # Declare a nested param under the `brainstem_model_name` root key,
       # i.e. `params[:blog_post][:id]`):
       model_params do |post|
-        post.valid :id, info: "the id of the post", required: true
+        post.valid :id, :integer, info: "the id of the post", required: true
       end
     end
 
 
     actions :create do
       model_params :post do |params|
-        params.valid :message,
-          type: "string",
+        params.valid :message, :string,
           info: "the id of the post",
           required: true
 
-        params.valid :viewable_by,
-          type: "array",
-          item: "integer",
+        params.valid :viewable_by, :array,          
+          item_type: :integer,
           info: "an array of user ids that can access the post"
       end
     end

--- a/lib/brainstem/api_docs/formatters/markdown/endpoint_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/markdown/endpoint_formatter.rb
@@ -120,6 +120,7 @@ module Brainstem
           #
           # @param [String] name the param name
           # @param [Hash] options information pertinent to the param
+          # @option [Boolean] options :required
           # @option [Boolean] options :legacy
           # @option [Boolean] options :recursive
           # @option [String,Symbol] options :only Deprecated: use +actions+
@@ -136,6 +137,7 @@ module Brainstem
 
             if options.keys.any?
               text += "\n"
+              text += md_li("Required: #{options[:required].to_s}",   indent + 1) if options.has_key?(:required) && options[:required]
               text += md_li("Legacy: #{options[:legacy].to_s}",       indent + 1) if options.has_key?(:legacy)
               text += md_li("Recursive: #{options[:recursive].to_s}", indent + 1) if options.has_key?(:recursive)
               text.chomp!

--- a/lib/brainstem/api_docs/formatters/markdown/endpoint_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/markdown/endpoint_formatter.rb
@@ -126,6 +126,10 @@ module Brainstem
           # @option [String,Symbol] options :only Deprecated: use +actions+
           #   block instead
           # @option [String] options :info the doc string for the param
+          # @option [String] options :type The type of the field.
+          #   e.g. string, integer, boolean, array, hash
+          # @option [String] options :item The type of the items in the field.
+          #   Ideally used when the type of the field is an array or hash.
           # @param [Integer] indent how many levels the output should be
           #   indented from normal
           #
@@ -133,6 +137,7 @@ module Brainstem
             options = options.dup
             text    = md_inline_code(title)
 
+            text += md_inline_type(options.delete(:type), options.delete(:item)) if options.has_key?(:type)
             text += " - #{options.delete(:info)}" if options.has_key?(:info)
 
             if options.keys.any?

--- a/lib/brainstem/api_docs/formatters/markdown/endpoint_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/markdown/endpoint_formatter.rb
@@ -128,7 +128,7 @@ module Brainstem
           # @option [String] options :info the doc string for the param
           # @option [String] options :type The type of the field.
           #   e.g. string, integer, boolean, array, hash
-          # @option [String] options :item The type of the items in the field.
+          # @option [String] options :item_type The type of the items in the field.
           #   Ideally used when the type of the field is an array or hash.
           # @param [Integer] indent how many levels the output should be
           #   indented from normal
@@ -137,7 +137,7 @@ module Brainstem
             options = options.dup
             text    = md_inline_code(title)
 
-            text += md_inline_type(options.delete(:type), options.delete(:item)) if options.has_key?(:type)
+            text += md_inline_type(options.delete(:type), options.delete(:item_type)) if options.has_key?(:type)
             text += " - #{options.delete(:info)}" if options.has_key?(:info)
 
             if options.keys.any?

--- a/lib/brainstem/api_docs/formatters/markdown/helper.rb
+++ b/lib/brainstem/api_docs/formatters/markdown/helper.rb
@@ -69,6 +69,15 @@ module Brainstem
           def md_a(text, link)
             "[#{text}](#{link})"
           end
+
+
+          def md_inline_type(type, item_type = nil)
+            return "" if type.blank?
+
+            text = type.to_s.capitalize
+            text += "<#{item_type.to_s.capitalize}>" if item_type.present?
+            " (#{md_inline_code(text)})"
+          end
         end
       end
     end

--- a/lib/brainstem/api_docs/formatters/markdown/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/markdown/presenter_formatter.rb
@@ -62,7 +62,7 @@ module Brainstem
 
           def format_field_leaf(field, indent_level)
             text = md_inline_code(field.name.to_s)
-            text << " (#{md_inline_code(field.type.to_s.capitalize)})"
+            text << md_inline_type(field.type, field.options[:item_type])
 
             text << "\n"
             text << md_li(field.description, indent_level + 1) if field.description

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -145,11 +145,15 @@ module Brainstem
         # @option options [Boolean] :required if the param is required for
         #   the endpoint
         #
-        def valid(field_name, options = { nodoc: false, required: false })
+        def valid(field_name, options = {})
           valid_params = configuration[brainstem_params_context][:valid_params]
-          valid_params[field_name.to_sym] = options
+
+          options[:type] = options[:type].to_s if options.has_key?(:type)
+          valid_params[field_name.to_sym] = DEFAULT_PARAM_OPTIONS.merge(options)
         end
 
+        DEFAULT_PARAM_OPTIONS = { nodoc: false, required: false, type: 'string' }
+        private_constant :DEFAULT_PARAM_OPTIONS
 
         #
         # Adds a transform to the list of transforms. Used to rename incoming

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -145,7 +145,7 @@ module Brainstem
         #   documentation?
         # @option options [Boolean] :required if the param is required for
         #   the endpoint
-        # @option options [String,Symbol] :item The data type of the items contained in a field.
+        # @option options [String,Symbol] :item_type The data type of the items contained in a field.
         #   Ideally used when the data type of the field is an `array`, `object` or `hash`.
         #
         def valid(field_name, type = nil, options = {})
@@ -244,7 +244,7 @@ module Brainstem
           options = type if type.is_a?(Hash) && options.empty?
 
           options[:type] = sanitize_param_data_type(type)
-          options[:item] = options[:item].to_s if options.has_key?(:item)
+          options[:item_type] = options[:item_type].to_s if options.has_key?(:item_type)
           DEFAULT_PARAM_OPTIONS.merge(options)
         end
 

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -142,8 +142,10 @@ module Brainstem
         #   under which param should it be nested?
         # @option options [Boolean] :nodoc should this param appear in the
         #   documentation?
+        # @option options [Boolean] :required if the param is required for
+        #   the endpoint
         #
-        def valid(field_name, options = { nodoc: false })
+        def valid(field_name, options = { nodoc: false, required: false })
           valid_params = configuration[brainstem_params_context][:valid_params]
           valid_params[field_name.to_sym] = options
         end

--- a/lib/brainstem/dsl/field.rb
+++ b/lib/brainstem/dsl/field.rb
@@ -9,7 +9,7 @@ module Brainstem
 
       def initialize(name, type, options)
         @name = name.to_s
-        @type = type
+        @type = type.to_s
         @conditionals = [options[:if]].flatten.compact
         @options = options
       end

--- a/lib/brainstem/dsl/fields_block.rb
+++ b/lib/brainstem/dsl/fields_block.rb
@@ -18,6 +18,11 @@ module Brainstem
             opts.merge!(if: if_clause) if if_clause.present?
           end
         end
+
+        def format_options(options)
+          options[:item_type] = options[:item_type].to_s if options.has_key?(:item_type)
+          super
+        end
       end
     end
   end

--- a/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
@@ -137,7 +137,7 @@ module Brainstem
               context "with valid params" do
                 let(:show_config) { {
                   valid_params: {
-                    only: { info: "which ids to include", nodoc: nodoc, type: "array", item: "integer" },
+                    only: { info: "which ids to include", nodoc: nodoc, type: "array", item_type: "integer" },
                     sprocket_id: { info: "the id of the sprocket", root: "widget", nodoc: nodoc, type: "integer" },
                     sprocket_child: { recursive: true, legacy: false, info: "it does the thing", root: "widget", type: "string" },
                   }

--- a/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
@@ -137,9 +137,9 @@ module Brainstem
               context "with valid params" do
                 let(:show_config) { {
                   valid_params: {
-                    only: { info: "which ids to include", nodoc: nodoc },
-                    sprocket_id: { info: "the id of the sprocket", root: "widget", nodoc: nodoc },
-                    sprocket_child: { recursive: true, legacy: false, info: "it does the thing", root: "widget" },
+                    only: { info: "which ids to include", nodoc: nodoc, type: "array", item: "integer" },
+                    sprocket_id: { info: "the id of the sprocket", root: "widget", nodoc: nodoc, type: "integer" },
+                    sprocket_child: { recursive: true, legacy: false, info: "it does the thing", root: "widget", type: "string" },
                   }
                 } }
 
@@ -169,12 +169,12 @@ module Brainstem
 
                   context "for non-root params" do
                     it "outputs sub params under a list item" do
-                      expect(subject.output).to include "- `widget`\n    - `sprocket_id` - the id of the sprocket\n    - `sprocket_child`"
+                      expect(subject.output).to include "- `widget`\n    - `sprocket_id` (`Integer`) - the id of the sprocket\n    - `sprocket_child` (`String`)"
                     end
                   end
 
                   it "includes the info on a hash key" do
-                    expect(subject.output).to include "`sprocket_child` - it does the thing"
+                    expect(subject.output).to include "`sprocket_child` (`String`) - it does the thing"
                   end
 
                   it "includes the recursivity if specified" do

--- a/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
@@ -173,6 +173,12 @@ module Brainstem
                     end
                   end
 
+                  context "for params with type array" do
+                    it "outputs item type along with the field type" do
+                      expect(subject.output).to include "- `only` (`Array<Integer>`) - which ids to include\n"
+                    end
+                  end
+
                   it "includes the info on a hash key" do
                     expect(subject.output).to include "`sprocket_child` (`String`) - it does the thing"
                   end

--- a/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/endpoint_formatter_spec.rb
@@ -184,6 +184,36 @@ module Brainstem
                   it "includes the legacy status if specified" do
                     expect(subject.output).to include "Legacy: false"
                   end
+
+                  context "when required option is specified" do
+                    context "when required is true" do
+                      let(:show_config) { {
+                        valid_params: {
+                          only: { info: "which ids to include", nodoc: nodoc },
+                          sprocket_id: { info: "the id of the sprocket", root: "widget", nodoc: nodoc, required: true },
+                          sprocket_child: { recursive: true, legacy: false, info: "it does the thing", root: "widget" },
+                        }
+                      } }
+
+                      it "includes if required" do
+                        expect(subject.output).to include "Required: true"
+                      end
+                    end
+
+                    context "when required is false" do
+                      let(:show_config) { {
+                        valid_params: {
+                          only: { info: "which ids to include", nodoc: nodoc },
+                          sprocket_id: { info: "the id of the sprocket", root: "widget", nodoc: nodoc, required: false },
+                          sprocket_child: { recursive: true, legacy: false, info: "it does the thing", root: "widget" },
+                        }
+                      } }
+
+                      it "includes if required" do
+                        expect(subject.output).to_not include "Required"
+                      end
+                    end
+                  end
                 end
               end
 
@@ -212,6 +242,7 @@ module Brainstem
                   end
                 end
               end
+
 
               context "with no valid params" do
                 it "outputs nothing" do

--- a/spec/brainstem/api_docs/formatters/markdown/helper_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/helper_spec.rb
@@ -93,6 +93,25 @@ module Brainstem
               expect(subject.md_a("text", "link.md")).to eq "[text](link.md)"
             end
           end
+
+
+          describe "#md_inline_type" do
+            it "renders the code between single backticks" do
+              expect(subject.md_inline_type("string")).to eq " (`String`)"
+            end
+
+            context "when type is blank" do
+              it "returns an empty string" do
+                expect(subject.md_inline_type("")).to eq ""
+              end
+            end
+
+            context "when item type is specified" do
+              it "renders the code between single backticks" do
+                expect(subject.md_inline_type("array", "integer")).to eq " (`Array<Integer>`)"
+              end
+            end
+          end
         end
       end
     end

--- a/spec/brainstem/api_docs/formatters/markdown/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/presenter_formatter_spec.rb
@@ -221,6 +221,25 @@ module Brainstem
                         end
                       end
                     end
+
+                    describe "when field has an item type" do
+                      let(:sprocket_ids) { OpenStruct.new(
+                          name:        :sprocket_ids,
+                          description: lorem,
+                          type:        :array,
+                          options:     { item_type: :integer }
+                        )
+                      }
+                      let(:valid_fields) { { sprocket_ids: sprocket_ids } }
+
+                      before do
+                        stub(sprocket_ids).optional? { optional }
+                      end
+
+                      it "outputs each field's type along with the sub item type" do
+                        expect(subject.output).to include "`sprocket_ids` (`Array<Integer>`)"
+                      end
+                    end
                   end
 
 

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -127,15 +127,17 @@ module Brainstem
         context "when given a name and an options hash" do
           it "appends to the valid params hash" do
             subject.brainstem_params do
-              valid :sprocket_name, :string,
-                info: "sprockets[sprocket_name] is required",
-                required: true
+              valid :sprocket_ids, :array,
+                info: "sprockets[sprocket_ids] is required",
+                required: true,
+                item: :integer
             end
 
-            expect(subject.configuration[:_default][:valid_params][:sprocket_name][:info]).to \
-              eq "sprockets[sprocket_name] is required"
-            expect(subject.configuration[:_default][:valid_params][:sprocket_name][:required]).to be_truthy
-            expect(subject.configuration[:_default][:valid_params][:sprocket_name][:type]).to eq('string')
+            expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:info]).to \
+              eq "sprockets[sprocket_ids] is required"
+            expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:required]).to be_truthy
+            expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:type]).to eq('array')
+            expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:item]).to eq('integer')
           end
         end
 

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -130,14 +130,14 @@ module Brainstem
               valid :sprocket_ids, :array,
                 info: "sprockets[sprocket_ids] is required",
                 required: true,
-                item: :integer
+                item_type: :integer
             end
 
             expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:info]).to \
               eq "sprockets[sprocket_ids] is required"
             expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:required]).to be_truthy
             expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:type]).to eq('array')
-            expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:item]).to eq('integer')
+            expect(subject.configuration[:_default][:valid_params][:sprocket_ids][:item_type]).to eq('integer')
           end
         end
 

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -115,10 +115,10 @@ module Brainstem
         end
 
         it "merges options" do
-          mock(subject).valid(:thing, root: "widgets", nodoc: true)
+          mock(subject).valid(:thing, root: "widgets", nodoc: true, required: true)
 
           subject.model_params :widgets do |param|
-            param.valid :thing, nodoc: true
+            param.valid :thing, nodoc: true, required: true
           end
         end
       end
@@ -128,11 +128,13 @@ module Brainstem
           it "appends to the valid params hash" do
             subject.brainstem_params do
               valid :sprocket_name,
-                info: "sprockets[sprocket_name] is required"
+                info: "sprockets[sprocket_name] is required",
+                required: true
             end
 
             expect(subject.configuration[:_default][:valid_params][:sprocket_name][:info]).to \
               eq "sprockets[sprocket_name] is required"
+            expect(subject.configuration[:_default][:valid_params][:sprocket_name][:required]).to be_truthy
           end
         end
 
@@ -141,7 +143,8 @@ module Brainstem
             # This is HWIA, so all keys are stringified
             data = {
               "recursive" => true,
-              "info" => "sprockets[sub_sprockets] is recursive and an array"
+              "info" => "sprockets[sub_sprockets] is recursive and an array",
+              "required" => true
             }
 
             subject.brainstem_params do
@@ -338,17 +341,19 @@ module Brainstem
 
           subject.brainstem_params do
             valid :unrelated_root_key,
-              info: "it's unrelated."
+              info: "it's unrelated.",
+              required: true
 
             model_params(brainstem_model_name) do |params|
               params.valid :sprocket_parent_id,
-                info: "sprockets[sprocket_parent_id] is required"
+                info: "sprockets[sprocket_parent_id] is not required"
             end
 
             actions :show do
               model_params(brainstem_model_name) do |params|
                 params.valid :sprocket_name,
-                  info: "sprockets[sprocket_name] is required"
+                  info: "sprockets[sprocket_name] is required",
+                  required: true
               end
             end
           end
@@ -371,8 +376,8 @@ module Brainstem
           stub.any_instance_of(subject).action_name { "show" }
 
           expect(subject.new.brainstem_valid_params).to eq({
-            "sprocket_name" => { "info" => "sprockets[sprocket_name] is required", "root" => "widget" },
-            "sprocket_parent_id" => { "info" => "sprockets[sprocket_parent_id] is required", "root" => "widget" }
+            "sprocket_name" => { "info" => "sprockets[sprocket_name] is required", "root" => "widget", "required" => true },
+            "sprocket_parent_id" => { "info" => "sprockets[sprocket_parent_id] is not required", "root" => "widget" }
           })
         end
 

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -243,22 +243,22 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(presenter_class.configuration[:fields].keys)
         .to match_array %w[updated_at dynamic_title secret member_ids bob_title nested_permissions]
 
-      expect(presenter_class.configuration[:fields][:updated_at].type).to eq :datetime
+      expect(presenter_class.configuration[:fields][:updated_at].type).to eq 'datetime'
       expect(presenter_class.configuration[:fields][:updated_at].description).to be_nil
 
-      expect(presenter_class.configuration[:fields][:dynamic_title].type).to eq :string
+      expect(presenter_class.configuration[:fields][:dynamic_title].type).to eq 'string'
       expect(presenter_class.configuration[:fields][:dynamic_title].description).to be_nil
       expect(presenter_class.configuration[:fields][:dynamic_title].options[:dynamic]).to be_a(Proc)
 
-      expect(presenter_class.configuration[:fields][:secret].type).to eq :string
+      expect(presenter_class.configuration[:fields][:secret].type).to eq 'string'
       expect(presenter_class.configuration[:fields][:secret].description).to be_nil
       expect(presenter_class.configuration[:fields][:secret].options).to eq({ via: :secret_info, if: [:user_is_bob, :title_is_hello] })
 
-      expect(presenter_class.configuration[:fields][:member_ids].type).to eq :array
+      expect(presenter_class.configuration[:fields][:member_ids].type).to eq 'array'
       expect(presenter_class.configuration[:fields][:member_ids].options[:item_type]).to eq 'integer'
       expect(presenter_class.configuration[:fields][:member_ids].options[:dynamic]).to be_a(Proc)
 
-      expect(presenter_class.configuration[:fields][:bob_title].type).to eq :string
+      expect(presenter_class.configuration[:fields][:bob_title].type).to eq 'string'
       expect(presenter_class.configuration[:fields][:bob_title].description).to eq 'another name for the title, only for Bob'
       expect(presenter_class.configuration[:fields][:bob_title].options).to eq(
         via: :title,
@@ -268,7 +268,7 @@ describe Brainstem::Concerns::PresenterDSL do
     end
 
     it 'handles nesting' do
-      expect(presenter_class.configuration[:fields][:nested_permissions][:something_title].type).to eq :string
+      expect(presenter_class.configuration[:fields][:nested_permissions][:something_title].type).to eq 'string'
       expect(presenter_class.configuration[:fields][:nested_permissions][:something_title].options[:via]).to eq :title
       expect(presenter_class.configuration[:fields][:nested_permissions][:random].options[:dynamic]).to be_a(Proc)
     end
@@ -350,15 +350,15 @@ describe Brainstem::Concerns::PresenterDSL do
       expect(subclass.configuration[:fields].keys)
         .to match_array %w[updated_at dynamic_title secret member_ids bob_title nested_permissions new_nested_permissions]
 
-      expect(presenter_class.configuration[:fields][:nested_permissions][:something_title].type).to eq :string
-      expect(presenter_class.configuration[:fields][:nested_permissions][:random].type).to eq :number
+      expect(presenter_class.configuration[:fields][:nested_permissions][:something_title].type).to eq 'string'
+      expect(presenter_class.configuration[:fields][:nested_permissions][:random].type).to eq 'number'
       expect(presenter_class.configuration[:fields][:nested_permissions][:new]).to be_nil
       expect(presenter_class.configuration[:fields][:nested_permissions][:deeper]).to be_nil
       expect(presenter_class.configuration[:fields][:new_nested_permissions]).to be_nil
 
-      expect(subclass.configuration[:fields][:nested_permissions][:something_title].type).to eq :number # changed this
-      expect(subclass.configuration[:fields][:nested_permissions][:random].type).to eq :number
-      expect(subclass.configuration[:fields][:nested_permissions][:new].type).to eq :string
+      expect(subclass.configuration[:fields][:nested_permissions][:something_title].type).to eq 'number' # changed this
+      expect(subclass.configuration[:fields][:nested_permissions][:random].type).to eq 'number'
+      expect(subclass.configuration[:fields][:nested_permissions][:new].type).to eq 'string'
       expect(subclass.configuration[:fields][:nested_permissions][:deeper][:something]).to be_present
       expect(subclass.configuration[:fields][:new_nested_permissions]).to be_present
     end
@@ -372,7 +372,7 @@ describe Brainstem::Concerns::PresenterDSL do
 
       it "is stored in the configuration correctly" do
         expect(presenter_class.configuration[:fields].keys).to include('synced_at')
-        expect(presenter_class.configuration[:fields][:synced_at].type).to eq :datetime
+        expect(presenter_class.configuration[:fields][:synced_at].type).to eq 'datetime'
         expect(presenter_class.configuration[:fields][:synced_at].description).to eq 'Last time the object was synced'
       end
     end


### PR DESCRIPTION
  - Add the capability to indicate an endpoint param is required with the `required` key in the options hash.
  ```
        params.valid :message, :text,
                     required: true,
                     info: "the message of the post"
  ```
  - Add support for specifying the type of an endpoint param. For an endpoint param that has type `Array`,
    type of list items can be specified using `item_type` key in the options hash.
  ```
        params.valid :viewable_by, :array,
                     item_type: :integer,
                     info: "an array of user ids that can access the post"
  ```
  - Add support for specifying the data type of an item for a presenter field using `item_type` key in the
    options hash when the field is of type `Array`.
  ```
        field :aliases, :array,
              item_type: :string,
              info: "an array of user ids that can access the post"
  ```
  - Include the type and item type when generating markdown documentation for endpoint params.  
  - Add support for generating markdown documentation when the `required` option is specified on an endpoint param.