### PR TITLE
Validate / Ignore Unknown Params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
++ **1.4.0** - _04/27/2018_
+  - Add the capability to validate params based on documented parameters on endpoints. Invoking
+    `brainstem_validate_params!` raises an error if unknown parameters are encountered.
+  - Add the capability to sanitize params based on documented parameters on endpoints. Invoking
+    `brainstem_sanitize_params` returns sanitized params while excluding unknown parameters.
+
 + **1.3.0** - _04/12/2018_
   - Add the capability to nest fields under executable parent blocks where the nested fields are evaluated
     with the resultant value of the parent field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 + **1.4.0** - _04/27/2018_
   - Add the capability to validate params based on documented parameters on endpoints. Invoking
     `brainstem_validate_params!` raises an error if unknown parameters are encountered.
-  - Add the capability to sanitize params based on documented parameters on endpoints. Invoking
-    `brainstem_sanitize_params` returns sanitized params while excluding unknown parameters.
+  - Add the capability to ignore unknown params based off documented parameters on endpoints. Invoking
+    `brainstem_ignore_unknown_params!` returns a copy of params while excluding unknown parameters.
 
 + **1.3.0** - _04/12/2018_
   - Add the capability to nest fields under evaluable parent blocks where the nested fields are evaluated

--- a/lib/brainstem/params_validator.rb
+++ b/lib/brainstem/params_validator.rb
@@ -1,0 +1,88 @@
+require 'brainstem/unknown_params'
+
+module Brainstem
+  class ParamsValidator
+    attr_reader :unknown_params, :sanitized_params
+
+    def self.validate!(action_name, input_params, valid_params_config, options = {})
+      new(action_name, input_params, valid_params_config, options).validate!
+    end
+
+    def initialize(action_name, input_params, valid_params_config, options = {})
+      @valid_params_config = valid_params_config
+      @options             = options
+      @input_params        = sanitize_input_params!(input_params)
+      @action_name         = action_name.to_s
+
+      @unknown_params      = []
+      @sanitized_params    = {}
+    end
+
+    def validate!
+      @input_params.each do |param_key, param_value|
+        param = @valid_params_config[param_key]
+
+        if param.blank?
+          @unknown_params << param_key
+          next
+        end
+
+        param_config = param[:_config]
+        if param_config[:only].present? && !param_config[:only].map(&:to_s).include?(@action_name)
+          @unknown_params << param_key
+
+        elsif param_config[:recursive].to_s == 'true'
+          next if param_value.blank?
+
+          @sanitized_params[param_key] = validate_recursive_params!(param_config[:type], param_key, param_value)
+        else
+          @sanitized_params[param_key] = param_value
+        end
+      end
+
+      raise_with_unknown_params? ? unknown_params_error! : @sanitized_params
+    end
+
+    private
+
+    def validate_recursive_params!(param_type, param_key, param_value)
+      if param_type == 'hash'
+        validate_recursive_param(param_key, param_value)
+      else
+        param_value.each_with_index.map { |value, index| validate_recursive_param(param_key, value, index) }
+      end
+    end
+
+    def validate_recursive_param(param_key, param_value, index = nil)
+      begin
+        result = self.class.validate!(@action_name, param_value, @valid_params_config, @options)
+      rescue Brainstem::UnknownParams => e
+        @unknown_params << { param_key => e.unknown_params }
+      end
+
+      result
+    end
+
+    def raise_with_unknown_params?
+      !ignore_unknown_params? && @unknown_params.present?
+    end
+
+    def ignore_unknown_params?
+      @options[:ignore_unknown_fields].to_s == 'true'
+    end
+
+    def sanitize_input_params!(input_params)
+      missing_params_error! unless input_params.is_a?(Hash) && input_params.present?
+
+      input_params
+    end
+
+    def missing_params_error!
+      raise ::Brainstem::UnknownParams.new("Missing required parameters")
+    end
+
+    def unknown_params_error!
+      raise ::Brainstem::UnknownParams.new("Unknown params encountered", @unknown_params)
+    end
+  end
+end

--- a/lib/brainstem/unknown_params.rb
+++ b/lib/brainstem/unknown_params.rb
@@ -1,0 +1,4 @@
+module Brainstem
+  class UnknownParams < StandardError
+  end
+end

--- a/lib/brainstem/unknown_params.rb
+++ b/lib/brainstem/unknown_params.rb
@@ -1,4 +1,10 @@
 module Brainstem
   class UnknownParams < StandardError
+    attr_reader :unknown_params
+
+    def initialize(message = "Unidentified Params sighted", unknown_params = [])
+      @unknown_params = unknown_params
+      super(message)
+    end
   end
 end

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -1010,7 +1010,7 @@ module Brainstem
           expect(subject.new.brainstem_validate_params!(:update, brainstem_model_name)).to be_truthy
         end
 
-        context "when required parameters are invalid" do
+        context "when parameters are in an invalid format" do
           context "with an empty hash" do
             let(:input_params)  { {} }
 
@@ -1046,132 +1046,79 @@ module Brainstem
           let(:input_params) { { widget: { my_cool_param: "something" } } }
 
           it "lists unknown params" do
-            expect{
+            expect {
               subject.new.brainstem_validate_params!(:update, brainstem_model_name)
-            }.to raise_error(Brainstem::UnknownParams, "Unknown params: my_cool_param." )
+            }.to raise_error(Brainstem::UnknownParams, "Unknown params encountered")
+          end
+        end
+      end
+
+      describe "#brainstem_ignore_unknown_params!" do
+        let(:brainstem_model_name) { "widget" }
+        let(:input_params) { { widget: { sprocket_parent_id: 5, sprocket_name: 'gears' } } }
+
+        before do
+          stub(subject).brainstem_model_name { brainstem_model_name }
+          stub.any_instance_of(subject).brainstem_model_name { brainstem_model_name }
+          stub.any_instance_of(subject).params { input_params }
+
+          subject.brainstem_params do
+            actions :update do
+              model_params(brainstem_model_name) do |params|
+                params.valid :sprocket_parent_id, :long,
+                  info: "sprockets[sprocket_parent_id] is not required"
+
+                params.valid :sprocket_name, :string,
+                  info: "sprockets[sprocket_name] is required",
+                  required: true
+              end
+            end
           end
         end
 
-        context "when params are supplied to the wrong action" do
-          before do
-            subject.brainstem_params do
-              actions :create do |params|
-                model_params(brainstem_model_name) do |params|
-                  params.valid :sprocket_name, :string,
-                    info: "sprockets[sprocket_name] is required",
-                    required: true
-                end
-              end
+        it "returns sanitized params if params are OK" do
+          expect(subject.new.brainstem_ignore_unknown_params!(:update, brainstem_model_name)).
+            to eq(input_params[:widget].with_indifferent_access)
+        end
+
+        context "when parameters are in an invalid format" do
+          context "with an empty hash" do
+            let(:input_params)  { {} }
+
+            it "returns the empty hash" do
+              expect {
+                subject.new.brainstem_ignore_unknown_params!(:update, brainstem_model_name)
+              }.to raise_error(Brainstem::UnknownParams)
             end
           end
 
-          it "throws an unknown params error" do
-            expect{
-              subject.new.brainstem_validate_params!(:create, brainstem_model_name)
-            }.to raise_error(Brainstem::UnknownParams)
+          context "with a non-hash object" do
+            let(:input_params) { { widget: [{ foo: "bar" }] } }
+
+            it "returns the object" do
+              expect {
+                subject.new.brainstem_ignore_unknown_params!(:update, brainstem_model_name)
+              }.to raise_error(Brainstem::UnknownParams)
+            end
+          end
+
+          context "with nil" do
+            let(:input_params) { { widget: nil } }
+
+            it "returns false and says params are missing" do
+              expect {
+                subject.new.brainstem_validate_params!(:update, brainstem_model_name)
+              }.to raise_error(Brainstem::UnknownParams)
+            end
           end
         end
 
-        context "when `object` property is specified in options" do
-          let(:input_params) { { widget: { do_not_use: true } } }
+        context "when unknown params are present" do
+          let(:input_params) { { widget: { sprocket_parent_id: 5, sprocket_name: 'gears', my_cool_param: "something" } } }
 
-          it "uses the object instead of the default brainstem valid params" do
-            validate_params = subject.new.brainstem_validate_params!(
-              :update,
-              brainstem_model_name,
-              :object => { :sprocket_name => "present", :sprocket_parent_id => 0 }
-            )
-            expect(validate_params).to be_truthy
-          end
-        end
-
-        context "when recursive attribute is given" do
-          before do
-            subject.brainstem_params do
-              actions :create do
-                model_params(brainstem_model_name) do |params|
-                  params.valid :title, :string
-                  params.valid :old_title, :string, legacy: true
-                  params.valid :workspace_id, :integer, only: :update, info: "You need a workspace_id"
-                  params.valid :sub_tasks, :array, recursive: true, info: "Sub tasks params are incorrect"
-                end
-              end
-            end
-          end
-
-          context "when recursive attribute is an array" do
-            # Context                                Params For Sub tasks                   Error Message
-            TEST_CASES = [
-              ["params is empty",                    {},                                    "Missing required parameters for sub_tasks"],
-              ["params includes unknown attributes", { wang: :chung },                      "Unknown params for sub_tasks: wang"],
-              ["params includes only attribute",     { title: "Invalid", workspace_id: 0 }, "Unknown params for sub_tasks: workspace_id"]
-            ]
-
-            context "when attributes are invalid" do
-              context "when attribute is an array" do
-                TEST_CASES.each do |context_description, sub_task_params, error_message|
-                  context "when #{context_description}" do
-                    let(:input_params) { { title: "foo", sub_tasks: [sub_task_params] } }
-
-                    it "returns false" do
-                      expect {
-                        subject.new.brainstem_validate_params!(:create, brainstem_model_name)
-                      }.to raise_error(Brainstem::UnknownParams)
-                    end
-                  end
-                end
-              end
-
-              context "when attribute is a hash" do
-                TEST_CASES.each do |context_description, sub_task_params, error_message|
-                  context "when #{context_description}" do
-                    let(:input_params) { { title: "foo", sub_tasks: { 0 => sub_task_params } } }
-
-                    it "returns false" do
-                      expect {
-                        subject.new.brainstem_validate_params!(:create, brainstem_model_name)
-                      }.to raise_error(Brainstem::UnknownParams)
-                    end
-                  end
-                end
-              end
-            end
-
-            context "when attributes are valid" do
-              let(:input_params) { { widget: { title: "parent", sub_tasks: sub_task_params } } }
-
-              context "when attribute is nil" do
-                let(:sub_task_params) { nil }
-
-                it "returns true" do
-                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
-                end
-              end
-
-              context "when attribute is an empty array" do
-                let(:sub_task_params) { [] }
-
-                it "returns true" do
-                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
-                end
-              end
-
-              context "when attributes in an array" do
-                let(:sub_task_params) { [ { title: "child" } ] }
-
-                it "returns true" do
-                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
-                end
-              end
-
-              context "when attributes in an hash" do
-                let(:sub_task_params) { { 0 => { title: "child" } } }
-
-                it "returns true" do
-                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
-                end
-              end
-            end
+          it "returns the params without the unknown keys" do
+            expect(subject.new.brainstem_ignore_unknown_params!(:update, brainstem_model_name))
+              .to eq({ sprocket_parent_id: 5, sprocket_name: 'gears' }.with_indifferent_access)
           end
         end
       end

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -983,6 +983,199 @@ module Brainstem
         end
       end
 
+      describe "#brainstem_validate_params!" do
+        let(:brainstem_model_name) { "widget" }
+        let(:input_params) { { widget: { sprocket_parent_id: 5, sprocket_name: 'gears' } } }
+
+        before do
+          stub(subject).brainstem_model_name { brainstem_model_name }
+          stub.any_instance_of(subject).brainstem_model_name { brainstem_model_name }
+          stub.any_instance_of(subject).params { input_params }
+
+          subject.brainstem_params do
+            actions :update do
+              model_params(brainstem_model_name) do |params|
+                params.valid :sprocket_parent_id, :long,
+                  info: "sprockets[sprocket_parent_id] is not required"
+
+                params.valid :sprocket_name, :string,
+                  info: "sprockets[sprocket_name] is required",
+                  required: true
+              end
+            end
+          end
+        end
+
+        it "returns true if params are OK" do
+          expect(subject.new.brainstem_validate_params!(:update, brainstem_model_name)).to be_truthy
+        end
+
+        context "when required parameters are invalid" do
+          context "with an empty hash" do
+            let(:input_params)  { {} }
+
+            it "returns false and says params are missing" do
+              expect {
+                subject.new.brainstem_validate_params!(:update, brainstem_model_name)
+              }.to raise_error(Brainstem::UnknownParams)
+            end
+          end
+
+          context "with a non-hash object" do
+            let(:input_params) { { widget: [{ foo: "bar" }] } }
+
+            it "returns false and says params are missing" do
+              expect {
+                subject.new.brainstem_validate_params!(:update, brainstem_model_name)
+              }.to raise_error(Brainstem::UnknownParams)
+            end
+          end
+
+          context "with nil" do
+            let(:input_params) { { widget: nil } }
+
+            it "returns false and says params are missing" do
+              expect {
+                subject.new.brainstem_validate_params!(:update, brainstem_model_name)
+              }.to raise_error(Brainstem::UnknownParams)
+            end
+          end
+        end
+
+        context "when there are errors due to unknown params" do
+          let(:input_params) { { widget: { my_cool_param: "something" } } }
+
+          it "lists unknown params" do
+            expect{
+              subject.new.brainstem_validate_params!(:update, brainstem_model_name)
+            }.to raise_error(Brainstem::UnknownParams, "Unknown params: my_cool_param." )
+          end
+        end
+
+        context "when params are supplied to the wrong action" do
+          before do
+            subject.brainstem_params do
+              actions :create do |params|
+                model_params(brainstem_model_name) do |params|
+                  params.valid :sprocket_name, :string,
+                    info: "sprockets[sprocket_name] is required",
+                    required: true
+                end
+              end
+            end
+          end
+
+          it "throws an unknown params error" do
+            expect{
+              subject.new.brainstem_validate_params!(:create, brainstem_model_name)
+            }.to raise_error(Brainstem::UnknownParams)
+          end
+        end
+
+        context "when `object` property is specified in options" do
+          let(:input_params) { { widget: { do_not_use: true } } }
+
+          it "uses the object instead of the default brainstem valid params" do
+            validate_params = subject.new.brainstem_validate_params!(
+              :update,
+              brainstem_model_name,
+              :object => { :sprocket_name => "present", :sprocket_parent_id => 0 }
+            )
+            expect(validate_params).to be_truthy
+          end
+        end
+
+        context "when recursive attribute is given" do
+          before do
+            subject.brainstem_params do
+              actions :create do
+                model_params(brainstem_model_name) do |params|
+                  params.valid :title, :string
+                  params.valid :old_title, :string, legacy: true
+                  params.valid :workspace_id, :integer, only: :update, info: "You need a workspace_id"
+                  params.valid :sub_tasks, :array, recursive: true, info: "Sub tasks params are incorrect"
+                end
+              end
+            end
+          end
+
+          context "when recursive attribute is an array" do
+            # Context                                Params For Sub tasks                   Error Message
+            TEST_CASES = [
+              ["params is empty",                    {},                                    "Missing required parameters for sub_tasks"],
+              ["params includes unknown attributes", { wang: :chung },                      "Unknown params for sub_tasks: wang"],
+              ["params includes only attribute",     { title: "Invalid", workspace_id: 0 }, "Unknown params for sub_tasks: workspace_id"]
+            ]
+
+            context "when attributes are invalid" do
+              context "when attribute is an array" do
+                TEST_CASES.each do |context_description, sub_task_params, error_message|
+                  context "when #{context_description}" do
+                    let(:input_params) { { title: "foo", sub_tasks: [sub_task_params] } }
+
+                    it "returns false" do
+                      expect {
+                        subject.new.brainstem_validate_params!(:create, brainstem_model_name)
+                      }.to raise_error(Brainstem::UnknownParams)
+                    end
+                  end
+                end
+              end
+
+              context "when attribute is a hash" do
+                TEST_CASES.each do |context_description, sub_task_params, error_message|
+                  context "when #{context_description}" do
+                    let(:input_params) { { title: "foo", sub_tasks: { 0 => sub_task_params } } }
+
+                    it "returns false" do
+                      expect {
+                        subject.new.brainstem_validate_params!(:create, brainstem_model_name)
+                      }.to raise_error(Brainstem::UnknownParams)
+                    end
+                  end
+                end
+              end
+            end
+
+            context "when attributes are valid" do
+              let(:input_params) { { widget: { title: "parent", sub_tasks: sub_task_params } } }
+
+              context "when attribute is nil" do
+                let(:sub_task_params) { nil }
+
+                it "returns true" do
+                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
+                end
+              end
+
+              context "when attribute is an empty array" do
+                let(:sub_task_params) { [] }
+
+                it "returns true" do
+                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
+                end
+              end
+
+              context "when attributes in an array" do
+                let(:sub_task_params) { [ { title: "child" } ] }
+
+                it "returns true" do
+                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
+                end
+              end
+
+              context "when attributes in an hash" do
+                let(:sub_task_params) { { 0 => { title: "child" } } }
+
+                it "returns true" do
+                  expect(subject.new.brainstem_validate_params!(:create, brainstem_model_name)).to be_truthy
+                end
+              end
+            end
+          end
+        end
+      end
+
       describe "#transforms" do
         before do
           subject.brainstem_params do

--- a/spec/brainstem/params_validator_spec.rb
+++ b/spec/brainstem/params_validator_spec.rb
@@ -1,0 +1,294 @@
+require 'spec_helper'
+require 'brainstem/params_validator'
+
+describe Brainstem::ParamsValidator do
+  let(:valid_params_config) do
+    {
+      sprocket_parent_id: { :_config => { type: 'integer' } },
+      sprocket_name:      { :_config => { type: 'string' } }
+    }
+  end
+  let(:options) { {} }
+  let(:action_name) { :create }
+
+  subject { described_class.new(action_name, input_params, valid_params_config, options) }
+
+  context "when input params has valid keys" do
+    let(:input_params) { { sprocket_parent_id: 5, sprocket_name: 'gears' } }
+
+    it "returns sanitized params" do
+      expect(subject.validate!).to eq(input_params)
+    end
+
+    context "when recursive attribute is given" do
+      let(:valid_params_config) do
+        {
+          sprocket_parent_id: { :_config => { type: 'integer' } },
+          sprocket_name:      { :_config => { type: 'string' } },
+          sub_widget:         { :_config => { type: 'hash', recursive: true } },
+          sub_widgets:        { :_config => { type: 'array', item_type: 'hash', recursive: true } },
+        }
+      end
+      let(:action) { :create }
+
+      context "when recursive attribute is a hash" do
+        let(:input_params) do
+          {
+            sprocket_parent_id: 5,
+            sprocket_name: 'gears',
+            sub_widget: sub_widget_param
+          }
+        end
+
+        context "when attribute is nil" do
+          let(:sub_widget_param) { nil }
+
+          it "returns the sanitized attributes without the empty recursive param" do
+            expect(subject.validate!).to eq(input_params.except(:sub_widget))
+          end
+        end
+
+        context "when attribute is an empty hash" do
+          let(:sub_widget_param) { {} }
+
+          it "returns the sanitized attributes without the empty recursive param" do
+            expect(subject.validate!).to eq(input_params.except(:sub_widget))
+          end
+        end
+
+        context "when attributes are specified" do
+          let(:sub_widget_param) do
+            {
+              sprocket_parent_id: 15,
+              sprocket_name: 'ten gears',
+            }
+          end
+
+          it "returns the sanitized attributes" do
+            expect(subject.validate!).to eq(input_params)
+          end
+        end
+      end
+
+      context "when recursive attribute is an array" do
+        let(:input_params) do
+          {
+            sprocket_parent_id: 5,
+            sprocket_name: 'gears',
+            sub_widgets: sub_widgets_params
+          }
+        end
+
+        context "when attribute is nil" do
+          let(:sub_widgets_params) { nil }
+
+          it "returns the sanitized attributes without the empty recursive param" do
+            expect(subject.validate!).to eq(input_params.except(:sub_widgets))
+          end
+        end
+
+        context "when attribute is an empty array" do
+          let(:sub_widgets_params) { [] }
+
+          it "returns the sanitized attributes without the empty recursive param" do
+            expect(subject.validate!).to eq(input_params.except(:sub_widgets))
+          end
+        end
+
+        context "when attributes in an array" do
+          let(:sub_widgets_params) { [ { sprocket_parent_id: 15, sprocket_name: 'ten gears' } ] }
+
+          it "returns the sanitized attributes" do
+            expect(subject.validate!).to eq(input_params)
+          end
+        end
+
+        skip "(UNSUPPORTED) when attributes in an hash" do
+          let(:sub_widgets_params) { { 0 => { title: "child" } } }
+
+          it "returns the sanitized attributes" do
+            expect(subject.validate!).to eq(input_params)
+          end
+        end
+      end
+    end
+  end
+
+  context "when input parameters are invalid" do
+    context "with an empty hash" do
+      let(:input_params) { {} }
+
+      it "raises an missing params error" do
+        expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+      end
+    end
+
+    context "with a non-hash object" do
+      let(:input_params) { [{ foo: "bar" }] }
+
+      it "raises an missing params error" do
+        expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+      end
+    end
+
+    context "with nil" do
+      let(:input_params) { nil }
+
+      it "raises an missing params error" do
+        expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+      end
+    end
+  end
+
+  context "when `ignore_unknown_fields` is true" do
+    let(:options) { { ignore_unknown_fields: true } }
+
+    context "when params are supplied to the wrong action" do
+      let(:valid_params_config) do
+        {
+          sprocket_parent_id: { :_config => { type: 'integer', only: [:update] } },
+          sprocket_name:      { :_config => { type: 'string' } }
+        }
+      end
+      let(:input_params) { { sprocket_parent_id: 5, sprocket_name: 'gears' } }
+      let(:action) { :create }
+
+      it "returns the input params without the unknown params" do
+        expect(subject.validate!).to eq(input_params.except(:sprocket_parent_id))
+      end
+    end
+
+    context "when input params have unknown keys" do
+      let(:input_params) { { my_cool_param: "something" } }
+
+      it "returns the input params without the unknown params" do
+        expect(subject.validate!).to eq(input_params.except(:my_cool_param))
+      end
+
+      context "when recursive attribute has invalid / unknown values" do
+        let(:valid_params_config) do
+          {
+            sprocket_parent_id: { :_config => { type: 'integer' } },
+            sprocket_name:      { :_config => { type: 'string' } },
+            sub_widget:         { :_config => { type: 'hash', recursive: true } },
+            sub_widgets:        { :_config => { type: 'array', item_type: 'hash', recursive: true } },
+          }
+        end
+
+        context "when recursive attribute is a hash" do
+          let(:input_params) do
+            {
+              sprocket_parent_id: 5,
+              sprocket_name: 'gears',
+              sub_widget: {
+                invalid_id: 15,
+                sprocket_name: 'ten gears',
+              }
+            }
+          end
+
+          it "returns the input params without the unknown params" do
+            expect(subject.validate!).to eq({
+              sprocket_parent_id: 5,
+              sprocket_name: 'gears',
+              sub_widget: {
+                sprocket_name: 'ten gears',
+              }
+            })
+          end
+        end
+
+        context "when recursive attribute is an array" do
+          let(:input_params) do
+            {
+              sprocket_parent_id: 5,
+              sprocket_name: 'gears',
+              sub_widgets: [
+                { invalid_id: 15, sprocket_name: 'ten gears' }
+              ]
+            }
+          end
+
+          it "returns the input params without the unknown params" do
+            expect(subject.validate!).to eq({
+              sprocket_parent_id: 5,
+              sprocket_name: 'gears',
+              sub_widgets: [
+                { sprocket_name: 'ten gears' }
+              ]
+            })
+          end
+        end
+      end
+    end
+  end
+
+  context "when `ignore_unknown_fields` is false" do
+    context "when params are supplied to the wrong action" do
+      let(:valid_params_config) do
+        {
+          sprocket_parent_id: { :_config => { type: 'integer', only: [:update] } },
+          sprocket_name:      { :_config => { type: 'string' } }
+        }
+      end
+      let(:input_params) { { sprocket_parent_id: 5, sprocket_name: 'gears' } }
+      let(:action) { :create }
+
+      it "throws an unknown params error" do
+        expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+      end
+    end
+
+    context "when input params have unknown keys" do
+      let(:input_params) { { my_cool_param: "something" } }
+
+      it "lists unknown params" do
+        expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+      end
+
+      context "when recursive attribute has invalid / unknown properties" do
+        let(:valid_params_config) do
+          {
+            sprocket_parent_id: { :_config => { type: 'integer' } },
+            sprocket_name:      { :_config => { type: 'string' } },
+            sub_widget:         { :_config => { type: 'hash', recursive: true } },
+            sub_widgets:        { :_config => { type: 'array', item_type: 'hash', recursive: true } },
+          }
+        end
+
+        context "when recursive attribute is a hash" do
+          let(:input_params) do
+            {
+              sprocket_parent_id: 5,
+              sprocket_name: 'gears',
+              sub_widget: {
+                invalid_id: 15,
+                sprocket_name: 'ten gears',
+              }
+            }
+          end
+
+          it "raises an error" do
+            expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+          end
+        end
+
+        context "when recursive attribute is an array" do
+          let(:input_params) do
+            {
+              sprocket_parent_id: 5,
+              sprocket_name: 'gears',
+              sub_widgets: [
+                { invalid_id: 15, sprocket_name: 'ten gears' }
+              ]
+            }
+          end
+
+          it "raises an error" do
+            expect { subject.validate! }.to raise_error(Brainstem::UnknownParams)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -1220,7 +1220,7 @@ describe Brainstem::PresenterCollection do
 
     describe "for! method" do
       it "raises if there is no presenter for the given class" do
-        expect{ Brainstem.presenter_collection("v1").for!(String) }.to raise_error(ArgumentError)
+        expect { Brainstem.presenter_collection("v1").for!(String) }.to raise_error(ArgumentError)
       end
     end
 
@@ -1245,7 +1245,7 @@ describe Brainstem::PresenterCollection do
       end
 
       it "raises if there is no presenter for the given class" do
-        expect{ Brainstem.presenter_collection("v1").brainstem_key_for!(String) }.to raise_error(ArgumentError)
+        expect { Brainstem.presenter_collection("v1").brainstem_key_for!(String) }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
  - Add the capability to validate params based on documented parameters on endpoints. Invoking
    `brainstem_validate_params!` raises an error if unknown parameters are encountered.
  - Add the capability to ignore unknown params based on documented parameters on endpoints. Invoking
    `brainstem_ignore_unknown_params!` returns a copy of params while excluding unknown parameters.