### PR TITLE
Bugfix engine support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
++ **1.4.1** - _05/09/2018_
+  - Add the capability to specify an alternate base application / engine the routes are derived from.
+    This capability is specific to documemtation generation.
+
 + **1.3.0** - _04/12/2018_
   - Add the capability to nest fields under evaluable parent blocks where the nested fields are evaluated
     with the resulting value of the parent field.

--- a/lib/brainstem/api_docs.rb
+++ b/lib/brainstem/api_docs.rb
@@ -108,16 +108,11 @@ module Brainstem
     end
 
     #
-    # Defines the application or engine that all routes will be fetched from.
+    # Defines the alternate application or engine that all routes will be fetched from.
     #
-    # Is a proc because most relevant classes are not loaded until much
-    # later.
+    # @see Brainstem::ApiDocs::RailsIntrospector#base_application_class=
     #
-    # @see Brainstem::ApiDocs::RailsIntrospector#base_application_proc=
-    #
-    config_accessor(:base_application_proc) do
-      Proc.new { Rails.application }
-    end
+    config_accessor(:base_application_class) { nil }
 
 
     #

--- a/lib/brainstem/api_docs/introspectors/rails_introspector.rb
+++ b/lib/brainstem/api_docs/introspectors/rails_introspector.rb
@@ -48,8 +48,7 @@ module Brainstem
 
 
         #
-        # Returns the alternate application class or defaults to Rails.application class
-        # class.
+        # Returns the alternate application class or defaults to Rails.application
         #
         # @return [Class] The base application class
         #

--- a/lib/brainstem/api_docs/introspectors/rails_introspector.rb
+++ b/lib/brainstem/api_docs/introspectors/rails_introspector.rb
@@ -51,7 +51,7 @@ module Brainstem
         # Returns the alternate application class or defaults to Rails.application class
         # class.
         #
-        # @return [Array<Class>] an array of descendant classes
+        # @return [Class] The base application class
         #
         def base_application
           base_application_class.present? ? base_application_class.constantize : ::Rails.application
@@ -194,7 +194,7 @@ module Brainstem
         # to have been loaded, this may also return a Proc, which will be called
         # after the environment is loaded.
         #
-        # @return [String,Nil] returns the name of the application or engine
+        # @return [String,Nil] returns the name of the alternate application or engine.
         #
         def base_application_class
           proc_or_string = @base_application_class

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -49,6 +49,7 @@ module Brainstem
             args_for_introspector: {
               base_presenter_class:  ::Brainstem::ApiDocs.method(:base_presenter_class),
               base_controller_class: ::Brainstem::ApiDocs.method(:base_controller_class),
+              base_application_class: ::Brainstem::ApiDocs.method(:base_application_class),
             },
           },
         }
@@ -145,6 +146,11 @@ module Brainstem
 
           opts.on('--base-controller-class=CLASS', "which class to look up controllers on") do |o|
             options[:builder][:args_for_introspector][:base_controller_class] = o
+          end
+
+
+          opts.on('--base-application-class=CLASS', "which class to look up routes on") do |o|
+            options[:builder][:args_for_introspector][:base_application_class] = o
           end
 
 

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/spec/brainstem/api_docs/introspectors/rails_introspector_spec.rb
+++ b/spec/brainstem/api_docs/introspectors/rails_introspector_spec.rb
@@ -114,6 +114,43 @@ module Brainstem
             end
           end
 
+          describe "#base_application" do
+            before do
+              stub.any_instance_of(described_class).validate!
+            end
+
+            context "when custom base_application_class is not given" do
+              subject do
+                described_class.with_loaded_environment(default_args)
+              end
+
+              it "returns nil" do
+                expect(subject.send(:base_application_class)).to be_nil
+              end
+
+              it "returns the descendants of the base controller class" do
+                expect(subject.base_application).to eq(::Rails.application)
+              end
+            end
+
+            context "when custom base_application_class is given" do
+              subject do
+                described_class.with_loaded_environment(
+                  default_args.merge(base_application_class: "::FakeApiEngine")
+                )
+              end
+
+              it "allows the specification of a custom base_application_class" do
+                expect(subject.send(:base_application_class).to_s)
+                  .to eq "::FakeApiEngine"
+              end
+
+              it "returns the descendants of the base controller class" do
+                expect(subject.base_application).to eq(FakeApiEngine)
+              end
+            end
+          end
+
           describe "#routes" do
             let(:a_proc) { Object.new }
 
@@ -161,27 +198,10 @@ module Brainstem
             end
 
             context "with an alternate base application or engine provided" do
-              let(:base_application_proc) { Proc.new { FakeRailsApplication.new(true, routes) } }
-              let(:routes) { FakeRailsRoutesObject.new([route_1, route_2]) }
-              let(:route_1) {
-                FakeRailsRoute.new(
-                  "fake_descendant",
-                  FakeRailsRoutePathObject.new(spec: '/fake_route_1'),
-                  { controller: "fake_descendant", action: "show" },
-                  { :request_method => /^GET$/ }
-                )
-              }
-              let(:route_2) {
-                FakeRailsRoute.new(
-                  "fake_descendant",
-                  FakeRailsRoutePathObject.new(spec: '/fake_route_2'),
-                  { controller: "fake_descendant", action: "show" },
-                  { :request_method => /^GET$/ }
-                )
-              }
+              let(:base_application_class) { "FakeApiEngine" }
 
               subject do
-                described_class.with_loaded_environment(default_args.merge({ base_application_proc: base_application_proc }))
+                described_class.with_loaded_environment(default_args.merge({ base_application_class: base_application_class }))
               end
 
               it "recognizes the configured application or engine's routes" do

--- a/spec/brainstem/api_docs_spec.rb
+++ b/spec/brainstem/api_docs_spec.rb
@@ -21,7 +21,7 @@ module Brainstem
         output_extension
         base_presenter_class
         base_controller_class
-        base_application_proc
+        base_application_class
         document_empty_presenter_associations
         document_empty_presenter_filters
       ).each do |meth|

--- a/spec/brainstem/cli/generate_api_docs_command_spec.rb
+++ b/spec/brainstem/cli/generate_api_docs_command_spec.rb
@@ -33,6 +33,15 @@ module Brainstem
           end
         end
 
+        context "when --base-application-class" do
+          let(:args) { %w(--base-application-class=::Api::Engine) }
+
+          it "sets sink to a ControllerPresenterMultifileSink" do
+            expect(subject.options).to have_key :builder
+            expect(subject.options[:builder][:args_for_introspector][:base_application_class]).to eq("::Api::Engine")
+          end
+        end
+
         context "when --output-dir" do
           let(:args) { %w(--output-dir=./blah) }
 

--- a/spec/dummy/rails.rb
+++ b/spec/dummy/rails.rb
@@ -39,7 +39,6 @@ class Rails
   end
 end
 
-
 class FakeBasePresenter; end
 class FakeDescendantPresenter < FakeBasePresenter; end
 
@@ -47,3 +46,26 @@ class FakeBaseController; end
 class FakeDescendantController < FakeBaseController; end
 
 class FakeNonDescendantController; end
+
+class FakeApiEngine
+  def self.eager_load!;end
+  def self.routes
+    @routes ||= begin
+      route_1 = FakeRailsRoute.new(
+        "fake_descendant",
+        FakeRailsRoutePathObject.new(spec: '/fake_route_1'),
+        { controller: "fake_descendant", action: "show" },
+        { :request_method => /^GET$/ }
+      )
+
+      route_2 = FakeRailsRoute.new(
+        "fake_descendant",
+        FakeRailsRoutePathObject.new(spec: '/fake_route_2'),
+        { controller: "fake_descendant", action: "show" },
+        { :request_method => /^GET$/ }
+      )
+
+      FakeRailsRoutesObject.new([ route_1, route_2 ])
+    end
+  end
+end


### PR DESCRIPTION
Allow configuration of where to get routes from. Normally this will be Rails.application. However, we should also be able to configure an engine such as `Api::Engine`.