### PR TITLE
Generate documentation from associations

### DIFF
--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/response_definitions_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/response_definitions_formatter.rb
@@ -107,12 +107,7 @@ module Brainstem
                       }
                     }
                   },
-                  brainstem_key => {
-                    type: 'object',
-                    additionalProperties: {
-                      '$ref' => "#/definitions/#{model_klass}"
-                    }
-                  }
+                  brainstem_key => object_reference(model_klass)
                 }.merge(associated_properties)
               end
 
@@ -134,10 +129,14 @@ module Brainstem
                 brainstem_key = assoc_presenter.brainstem_keys.first
                 return if assoc_presenter.nodoc?
 
-                obj[brainstem_key] = {
+                obj[brainstem_key] = object_reference(target_class)
+              end
+
+              def object_reference(klass)
+                {
                   type: 'object',
                   additionalProperties: {
-                    '$ref' => "#/definitions/#{target_class.to_s}"
+                    '$ref' => "#/definitions/#{klass}"
                   }
                 }
               end

--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/response_definitions_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/response_definitions_formatter.rb
@@ -114,8 +114,8 @@ module Brainstem
               def associated_properties
                 presenter.valid_associations.each_with_object({}) do |(_key, association), obj|
                   if association.polymorphic?
-                    associations = association.polymorphic_classes || []
-                    associations.each do |assoc|
+                    associated_klasses = association.polymorphic_classes || []
+                    associated_klasses.each do |assoc|
                       association_reference(assoc, obj)
                     end
                   else

--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter.rb
@@ -98,13 +98,12 @@ module Brainstem
             end
 
             def association_key(association)
-              key = if association.foreign_key
+              if association.foreign_key
                 association.foreign_key
               else
-                "#{association.name.singularize}_id"
+                key = association.name.singularize
+                association.type == :has_many ? "#{key}_ids" : "#{key}_id"
               end
-
-              association.type == :has_many ? "#{key}s" : key
             end
 
             def format_field(field)

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -17,6 +17,18 @@ module Brainstem
         options[:info].presence
       end
 
+      def foreign_key
+        options[:foreign_key]
+      end
+
+      def polymorphic_classes
+        options[:polymorphic_classes]
+      end
+
+      def type
+        options[:type]
+      end
+
       def method_name
         if options[:dynamic] || options[:lookup]
           nil

--- a/spec/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter_spec.rb
@@ -152,14 +152,11 @@ module Brainstem
                   before do
                     presenter_class.associations do
                       association :task, Task,
-                        foreign_key: :task_id,
-                        type: :belongs_to,
-                        info: "Assign people to your task"
+                        type: :belongs_to
 
                       association :user, User,
                         foreign_key: :user_id,
-                        type: :has_one,
-                        info: "People are users"
+                        type: :has_one
                     end
                   end
 
@@ -168,8 +165,8 @@ module Brainstem
 
                     expect(subject.definition).to have_key :properties
                     expect(subject.definition[:properties]).to eq({
-                      'task_id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'Assign people to your task' },
-                      'user_id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'People are users' }
+                      'task_id' => { 'type' => 'integer', 'format' => 'int32', 'description' => '`task_id` will only be included in the response if `task` is in the list of included associations.' },
+                      'user_id' => { 'type' => 'integer', 'format' => 'int32', 'description' => '`user_id` will only be included in the response if `user` is in the list of included associations.' }
                     })
                   end
                 end
@@ -178,9 +175,7 @@ module Brainstem
                   before do
                     presenter_class.associations do
                       association :task, Task,
-                        foreign_key: :task_id,
-                        type: :has_many,
-                        info: "Assign people to your task"
+                        type: :has_many
                     end
                   end
 
@@ -191,7 +186,7 @@ module Brainstem
                     expect(subject.definition[:properties]).to eq({
                       'task_ids' => {
                         'type' => 'array',
-                        'description' => 'Assign people to your task',
+                        'description' => '`task_ids` will only be included in the response if `task` is in the list of included associations.',
                         'items' => {
                           'type' => 'integer',
                           'format' => 'int32'
@@ -204,9 +199,7 @@ module Brainstem
                 context 'when association is polymorphic' do
                   before do
                     presenter_class.associations do
-                      association :task, :polymorphic,
-                        polymorphic_classes: [User, Task],
-                        info: "Users and tasks"
+                      association :task, :polymorphic, polymorphic_classes: [User, Task]
                     end
                   end
 
@@ -217,7 +210,7 @@ module Brainstem
                     expect(subject.definition[:properties]).to eq({
                       'task_ref' => {
                         'type' => 'object',
-                        'description' => 'Users and tasks',
+                        'description' => '`task_ref` will only be included in the response if `task` is in the list of included associations.',
                         'properties' => {
                           'id' => {
                             'type' => 'string'

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -5,10 +5,13 @@ describe Brainstem::DSL::Association do
   let(:name) { :user }
   let(:target_class) { User }
   let(:description) { "This object's user" }
-  let(:options) { { info: description } }
+  let(:type) { :belongs_to }
+  let(:foreign_key) { :user_id }
+  let(:polymorphic_classes) { [User, Task] }
+  let(:options) { { info: description, foreign_key: foreign_key, type: type, polymorphic_classes: polymorphic_classes } }
   let(:association) { Brainstem::DSL::Association.new(name, target_class, options) }
 
-  describe 'description' do
+  describe '#description' do
     context 'when `info` is specified in the options' do
       it 'returns the value specified with the info key' do
         expect(association.description).to eq(description)
@@ -24,8 +27,56 @@ describe Brainstem::DSL::Association do
     end
   end
 
+  describe '#foreign_key' do
+    context 'when `foreign_key` is specified in the options' do
+      it 'returns the value specified with the foreign_key key' do
+        expect(association.foreign_key).to eq(foreign_key)
+      end
+    end
+
+    context 'when `foreign_key` is not specified in the options' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(association.foreign_key).to be_nil
+      end
+    end
+  end
+
+  describe '#type' do
+    context 'when `type` is specified in the options' do
+      it 'returns the value specified with the type key' do
+        expect(association.type).to eq(type)
+      end
+    end
+
+    context 'when `type` is not specified in the options' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(association.type).to be_nil
+      end
+    end
+  end
+
+  describe '#polymorphic_classes' do
+    context 'when `polymorphic_classes` is specified in the options' do
+      it 'returns the value specified with the polymorphic_classes key' do
+        expect(association.polymorphic_classes).to eq(polymorphic_classes)
+      end
+    end
+
+    context 'when `polymorphic_classes` is not specified in the options' do
+      let(:options) { {} }
+
+      it 'returns nil' do
+        expect(association.polymorphic_classes).to be_nil
+      end
+    end
+  end
+
   describe "#run_on" do
-    let(:context) { { } }
+    let(:context) { {} }
 
     context 'with no special options' do
       it 'calls the method by name on the model' do


### PR DESCRIPTION
- Associations supported are `has_many`, `has_one`, `belongs_to` as well as `polymorphic` associations

Signed-off-by: Dor Dan <ddan@mavenlink.com>