### PR TITLE
Add `--include-internal` option to CLI tool.

### DIFF
--- a/lib/brainstem/api_docs/atlas.rb
+++ b/lib/brainstem/api_docs/atlas.rb
@@ -18,9 +18,9 @@ module Brainstem
       include Concerns::Optional
 
       def initialize(introspector, options = {})
-        self.endpoints          = EndpointCollection.new(self)
-        self.controllers        = ControllerCollection.new(self)
-        self.presenters         = ::Brainstem::ApiDocs::PresenterCollection.new(self)
+        self.endpoints          = EndpointCollection.new(self, options)
+        self.controllers        = ControllerCollection.new(self, options)
+        self.presenters         = ::Brainstem::ApiDocs::PresenterCollection.new(self, options)
         self.resolver           = Resolver.new(self)
 
         self.controller_matches = []

--- a/lib/brainstem/api_docs/controller.rb
+++ b/lib/brainstem/api_docs/controller.rb
@@ -23,7 +23,7 @@ module Brainstem
                     :endpoints,
                     :filename_pattern,
                     :atlas,
-                    :internal
+                    :include_internal
 
       attr_writer   :filename_pattern,
                     :filename_link_pattern
@@ -35,7 +35,7 @@ module Brainstem
           :formatters,
           :filename_pattern,
           :filename_link_pattern,
-          :internal
+          :include_internal
         ]
       end
 
@@ -114,7 +114,7 @@ module Brainstem
       private
 
       def nodoc_for?(config)
-        !!(config[:nodoc] || (config[:internal] && !internal))
+        !!(config[:nodoc] || (config[:internal] && !include_internal))
       end
     end
   end

--- a/lib/brainstem/api_docs/controller.rb
+++ b/lib/brainstem/api_docs/controller.rb
@@ -22,7 +22,8 @@ module Brainstem
                     :name,
                     :endpoints,
                     :filename_pattern,
-                    :atlas
+                    :atlas,
+                    :internal
 
       attr_writer   :filename_pattern,
                     :filename_link_pattern
@@ -33,7 +34,8 @@ module Brainstem
           :name,
           :formatters,
           :filename_pattern,
-          :filename_link_pattern
+          :filename_link_pattern,
+          :internal
         ]
       end
 
@@ -77,7 +79,7 @@ module Brainstem
       end
 
       def nodoc?
-        default_configuration[:nodoc]
+        nodoc_for?(default_configuration)
       end
 
       def title
@@ -101,12 +103,18 @@ module Brainstem
       #
       def contextual_documentation(key)
         default_configuration.has_key?(key) &&
-          !default_configuration[key][:nodoc] &&
+          !nodoc_for?(default_configuration[key]) &&
           default_configuration[key][:info]
       end
 
       def valid_sorted_endpoints
         endpoints.sorted_with_actions_in_controller(const)
+      end
+
+      private
+
+      def nodoc_for?(config)
+        !!(config[:nodoc] || (config[:internal] && !internal))
       end
     end
   end

--- a/lib/brainstem/api_docs/controller_collection.rb
+++ b/lib/brainstem/api_docs/controller_collection.rb
@@ -5,13 +5,22 @@ module Brainstem
   module ApiDocs
     class ControllerCollection < AbstractCollection
 
+      attr_accessor :internal
+
+      def valid_options
+        super | [
+          :internal
+        ]
+      end
+
       #
       # Creates a new controller from a route object and appends it to the
       # collection.
       def create_from_route(route)
         Controller.new(atlas,
-          const:  route[:controller],
-          name:   route[:controller_name].split("/").last
+          const:    route[:controller],
+          name:     route[:controller_name].split("/").last,
+          internal: internal
         ).tap { |controller| self.<< controller }
       end
 

--- a/lib/brainstem/api_docs/controller_collection.rb
+++ b/lib/brainstem/api_docs/controller_collection.rb
@@ -5,11 +5,11 @@ module Brainstem
   module ApiDocs
     class ControllerCollection < AbstractCollection
 
-      attr_accessor :internal
+      attr_accessor :include_internal
 
       def valid_options
         super | [
-          :internal
+          :include_internal
         ]
       end
 
@@ -18,9 +18,9 @@ module Brainstem
       # collection.
       def create_from_route(route)
         Controller.new(atlas,
-          const:    route[:controller],
-          name:     route[:controller_name].split("/").last,
-          internal: internal
+          const:            route[:controller],
+          name:             route[:controller_name].split("/").last,
+          include_internal: include_internal
         ).tap { |controller| self.<< controller }
       end
 

--- a/lib/brainstem/api_docs/endpoint.rb
+++ b/lib/brainstem/api_docs/endpoint.rb
@@ -24,7 +24,7 @@ module Brainstem
           :controller_name,
           :action,
           :presenter,
-          :internal
+          :include_internal
         ]
       end
 
@@ -40,7 +40,7 @@ module Brainstem
                     :controller_name,
                     :action,
                     :atlas,
-                    :internal
+                    :include_internal
 
       #
       # Pretty prints each endpoint.
@@ -313,7 +313,7 @@ module Brainstem
       private
 
       def nodoc_for?(config)
-        !!(config[:nodoc] || (config[:internal] && !internal))
+        !!(config[:nodoc] || (config[:internal] && !include_internal))
       end
     end
   end

--- a/lib/brainstem/api_docs/endpoint.rb
+++ b/lib/brainstem/api_docs/endpoint.rb
@@ -23,7 +23,8 @@ module Brainstem
           :controller,
           :controller_name,
           :action,
-          :presenter
+          :presenter,
+          :internal
         ]
       end
 
@@ -38,7 +39,8 @@ module Brainstem
                     :controller,
                     :controller_name,
                     :action,
-                    :atlas
+                    :atlas,
+                    :internal
 
       #
       # Pretty prints each endpoint.
@@ -94,7 +96,7 @@ module Brainstem
       # Is the entire endpoint undocumentable?
       #
       def nodoc?
-        action_configuration[:nodoc]
+        nodoc_for?(action_configuration)
       end
 
       def title
@@ -156,7 +158,8 @@ module Brainstem
             .with_indifferent_access
             .inject(ActiveSupport::HashWithIndifferentAccess.new) do |result, (field_name_proc, field_config)|
 
-            next result if field_config[:nodoc]
+            next result if nodoc_for?(field_config)
+            field_config = field_config.except(:nodoc, :internal)
 
             field_name = evaluate_field_name(field_name_proc)
             if field_config.has_key?(:ancestors)
@@ -199,7 +202,8 @@ module Brainstem
             .except(:_config)
             .inject(custom_config_tree) do |result, (field_name_proc, field_config)|
 
-            next result if field_config[:nodoc]
+            next result if nodoc_for?(field_config)
+            field_config = field_config.except(:nodoc, :internal)
 
             field_name = evaluate_field_name(field_name_proc)
             if field_config.has_key?(:ancestors)
@@ -243,7 +247,7 @@ module Brainstem
       #
       def declared_presented_class
         valid_presents.has_key?(:target_class) &&
-          !valid_presents[:nodoc] &&
+          !nodoc_for?(valid_presents) &&
           valid_presents[:target_class]
       end
 
@@ -281,7 +285,7 @@ module Brainstem
       #
       def contextual_documentation(key)
         action_configuration.has_key?(key) &&
-          !action_configuration[key][:nodoc] &&
+          !nodoc_for?(action_configuration[key]) &&
           action_configuration[key][:info]
       end
 
@@ -304,6 +308,12 @@ module Brainstem
 
           presenter_path.relative_path_from(controller_path).to_s
         end
+      end
+
+      private
+
+      def nodoc_for?(config)
+        !!(config[:nodoc] || (config[:internal] && !internal))
       end
     end
   end

--- a/lib/brainstem/api_docs/endpoint_collection.rb
+++ b/lib/brainstem/api_docs/endpoint_collection.rb
@@ -7,6 +7,14 @@ module Brainstem
     class EndpointCollection < AbstractCollection
       include Concerns::Formattable
 
+      attr_accessor :internal
+
+      def valid_options
+        super | [
+          :internal
+        ]
+      end
+
       def find_from_route(route)
         find do |endpoint|
           endpoint.path == route[:path] &&
@@ -18,7 +26,7 @@ module Brainstem
       alias_method :find_by_route, :find_from_route
 
       def create_from_route(route, controller)
-        Endpoint.new(atlas) do |ep|
+        Endpoint.new(atlas, internal: self.internal) do |ep|
           ep.path             = route[:path]
           ep.http_methods     = route[:http_methods]
           ep.controller       = controller

--- a/lib/brainstem/api_docs/endpoint_collection.rb
+++ b/lib/brainstem/api_docs/endpoint_collection.rb
@@ -7,11 +7,11 @@ module Brainstem
     class EndpointCollection < AbstractCollection
       include Concerns::Formattable
 
-      attr_accessor :internal
+      attr_accessor :include_internal
 
       def valid_options
         super | [
-          :internal
+          :include_internal
         ]
       end
 
@@ -26,7 +26,7 @@ module Brainstem
       alias_method :find_by_route, :find_from_route
 
       def create_from_route(route, controller)
-        Endpoint.new(atlas, internal: self.internal) do |ep|
+        Endpoint.new(atlas, include_internal: self.include_internal) do |ep|
           ep.path             = route[:path]
           ep.http_methods     = route[:http_methods]
           ep.controller       = controller

--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter.rb
@@ -31,6 +31,7 @@ module Brainstem
               format_description!
               format_type!
               format_fields!
+              sort_properties!
 
               output.merge!(presenter.target_class => definition.reject {|_, v| v.blank?})
             end
@@ -41,6 +42,12 @@ module Brainstem
 
             def format_title!
               definition.merge! title: presenter_title(presenter)
+            end
+
+            def sort_properties!
+              definition[:properties] = definition[:properties].sort.each_with_object({}) do |(key, val), obj|
+                obj[key] = val
+              end if definition[:properties]
             end
 
             def format_description!
@@ -84,9 +91,9 @@ module Brainstem
                 key = association_key(association)
                 description = association_description(key, association.name)
                 formatted_type = if association.type == :has_many
-                  type_and_format(:array, :integer)
+                  type_and_format(:array, :string)
                 else
-                  type_and_format(:integer)
+                  type_and_format(:string)
                 end.merge(description: description)
 
                 props[key] = formatted_type unless props[key]
@@ -94,12 +101,13 @@ module Brainstem
             end
 
             def association_description(key, name)
-              "`#{key}` will only be included in the response if `#{name}` is in the list of included associations."
+              ["`#{key}` will only be included in the response if `#{name}` is in the list of included associations.",
+                "See <a href='#section/Includes'>include</a> section for usage."].join(' ')
             end
 
             def association_key(association)
-              key = if association.foreign_key
-                association.foreign_key
+              key = if association.response_key
+                association.response_key
               else
                 "#{association.name.singularize}_id"
               end

--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter.rb
@@ -45,9 +45,11 @@ module Brainstem
             end
 
             def sort_properties!
+              return if definition[:properties].blank?
+
               definition[:properties] = definition[:properties].sort.each_with_object({}) do |(key, val), obj|
                 obj[key] = val
-              end if definition[:properties]
+              end
             end
 
             def format_description!

--- a/lib/brainstem/api_docs/presenter.rb
+++ b/lib/brainstem/api_docs/presenter.rb
@@ -21,14 +21,16 @@ module Brainstem
           :filename_pattern,
           :filename_link_pattern,
           :document_empty_associations,
-          :document_empty_filters
+          :document_empty_filters,
+          :internal
         ]
       end
 
       attr_accessor :const,
                     :target_class,
                     :document_empty_associations,
-                    :document_empty_filters
+                    :document_empty_filters,
+                    :internal
 
       attr_writer   :filename_pattern,
                     :filename_link_pattern
@@ -75,7 +77,7 @@ module Brainstem
       delegate :find_by_class => :atlas
 
       def nodoc?
-        configuration[:nodoc]
+        nodoc_for?(configuration)
       end
 
       def title
@@ -98,7 +100,7 @@ module Brainstem
       alias_method :valid_fields_in, :valid_fields
 
       def invalid_field?(field)
-        field.options[:nodoc]
+        nodoc_for?(field.options)
       end
 
       def nested_field?(field)
@@ -131,7 +133,7 @@ module Brainstem
       end
 
       def documentable_filter?(_, filter)
-        !filter[:nodoc] &&
+        !nodoc_for?(filter) &&
           (
             document_empty_filters? || # document empty filters or
             !(filter[:info] || "").empty? # has info string
@@ -143,7 +145,7 @@ module Brainstem
       end
 
       def valid_sort_orders
-        configuration[:sort_orders].to_h.reject {|k, v| v[:nodoc] }
+        configuration[:sort_orders].to_h.reject {|_k, v| nodoc_for?(v) }
       end
 
       def valid_associations
@@ -168,7 +170,7 @@ module Brainstem
       # @return [Bool] document this association?
       #
       def documentable_association?(_, association)
-        !association.options[:nodoc] && # not marked nodoc and
+        !nodoc_for?(association.options) && # not marked nodoc and
           (
             document_empty_associations? || # document empty associations or
             !(association.description.nil? || association.description.empty?) # has description
@@ -196,7 +198,7 @@ module Brainstem
       #
       def contextual_documentation(key)
         configuration.has_key?(key) &&
-          !configuration[key][:nodoc] &&
+          !nodoc_for?(configuration[key]) &&
           configuration[key][:info]
       end
 
@@ -209,6 +211,12 @@ module Brainstem
         presenter_path = Pathname.new(presenter.suggested_filename_link(format))
 
         presenter_path.relative_path_from(my_path).to_s
+      end
+
+      private
+
+      def nodoc_for?(config)
+        !!(config[:nodoc] || (config[:internal] && !internal))
       end
     end
   end

--- a/lib/brainstem/api_docs/presenter.rb
+++ b/lib/brainstem/api_docs/presenter.rb
@@ -22,7 +22,7 @@ module Brainstem
           :filename_link_pattern,
           :document_empty_associations,
           :document_empty_filters,
-          :internal
+          :include_internal
         ]
       end
 
@@ -30,7 +30,7 @@ module Brainstem
                     :target_class,
                     :document_empty_associations,
                     :document_empty_filters,
-                    :internal
+                    :include_internal
 
       attr_writer   :filename_pattern,
                     :filename_link_pattern
@@ -216,7 +216,7 @@ module Brainstem
       private
 
       def nodoc_for?(config)
-        !!(config[:nodoc] || (config[:internal] && !internal))
+        !!(config[:nodoc] || (config[:internal] && !include_internal))
       end
     end
   end

--- a/lib/brainstem/api_docs/presenter_collection.rb
+++ b/lib/brainstem/api_docs/presenter_collection.rb
@@ -9,10 +9,11 @@ module Brainstem
       include Concerns::Formattable
 
       def valid_options
-        super | [ :presenter_constant_lookup_method ]
+        super | [ :presenter_constant_lookup_method, :internal ]
       end
 
       attr_writer :presenter_constant_lookup_method
+      attr_accessor :internal
 
       #
       # Finds or creates a presenter with the given target class and appends it to the
@@ -39,7 +40,8 @@ module Brainstem
       def create_from_target_class(target_class)
         ::Brainstem::ApiDocs::Presenter.new(atlas,
           target_class: target_class,
-          const:        target_class_to_const(target_class)
+          const:        target_class_to_const(target_class),
+          internal: internal
         ).tap { |p| self.<< p }
       rescue KeyError
         nil
@@ -55,7 +57,8 @@ module Brainstem
       def create_from_presenter_collection(target_class, const)
         ::Brainstem::ApiDocs::Presenter.new(atlas,
           target_class: target_class,
-          const:        const
+          const:        const,
+          internal: internal
         ).tap { |p| self.<< p }
       end
 

--- a/lib/brainstem/api_docs/presenter_collection.rb
+++ b/lib/brainstem/api_docs/presenter_collection.rb
@@ -9,11 +9,11 @@ module Brainstem
       include Concerns::Formattable
 
       def valid_options
-        super | [ :presenter_constant_lookup_method, :internal ]
+        super | [ :presenter_constant_lookup_method, :include_internal ]
       end
 
       attr_writer :presenter_constant_lookup_method
-      attr_accessor :internal
+      attr_accessor :include_internal
 
       #
       # Finds or creates a presenter with the given target class and appends it to the
@@ -39,9 +39,9 @@ module Brainstem
       #
       def create_from_target_class(target_class)
         ::Brainstem::ApiDocs::Presenter.new(atlas,
-          target_class: target_class,
-          const:        target_class_to_const(target_class),
-          internal: internal
+          target_class:     target_class,
+          const:            target_class_to_const(target_class),
+          include_internal: include_internal
         ).tap { |p| self.<< p }
       rescue KeyError
         nil
@@ -56,9 +56,9 @@ module Brainstem
 
       def create_from_presenter_collection(target_class, const)
         ::Brainstem::ApiDocs::Presenter.new(atlas,
-          target_class: target_class,
-          const:        const,
-          internal: internal
+          target_class:     target_class,
+          const:            const,
+          include_internal: include_internal
         ).tap { |p| self.<< p }
       end
 

--- a/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
+++ b/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
@@ -20,6 +20,7 @@ module Brainstem
             :write_path,
             :oas_filename_pattern,
             :output_extension,
+            :internal
           ]
         end
 
@@ -32,7 +33,8 @@ module Brainstem
                       :ignore_tagging,
                       :oas_filename_pattern,
                       :output_extension,
-                      :output
+                      :output,
+                      :internal
 
         delegate [:controllers, :presenters] => :atlas
 

--- a/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
+++ b/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
@@ -20,7 +20,7 @@ module Brainstem
             :write_path,
             :oas_filename_pattern,
             :output_extension,
-            :internal
+            :include_internal
           ]
         end
 
@@ -34,7 +34,7 @@ module Brainstem
                       :oas_filename_pattern,
                       :output_extension,
                       :output,
-                      :internal
+                      :include_internal
 
         delegate [:controllers, :presenters] => :atlas
 

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -158,7 +158,7 @@ module Brainstem
             options[:sink][:options][:output_extension] = extension
           end
 
-          opts.on('--internal', 'Generate docs for all `internal!` flagged presenters/controllers') do |_|
+          opts.on('--include-internal', 'Generate docs for all `internal!` flagged presenters/controllers') do |_|
             options[:builder][:args_for_atlas][:internal] = true
           end
 

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -159,7 +159,7 @@ module Brainstem
           end
 
           opts.on('--include-internal', 'Generate docs for all `internal!` flagged presenters/controllers') do |_|
-            options[:builder][:args_for_atlas][:internal] = true
+            options[:builder][:args_for_atlas][:include_internal] = true
           end
 
           #########################################################

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -158,6 +158,10 @@ module Brainstem
             options[:sink][:options][:output_extension] = extension
           end
 
+          opts.on('--internal', 'Generate docs for all `internal!` flagged presenters/controllers') do |_|
+            options[:builder][:args_for_atlas][:internal] = true
+          end
+
           #########################################################
           #                                                       #
           # Open API Specification generation specific commands:  #

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -70,7 +70,7 @@ module Brainstem
         end
 
         #
-        # Specifies that the scope should not be documented unless the `--internal`
+        # Specifies that the scope should not be documented unless the `--include-internal`
         # flag is passed in the CLI. Setting this on the default context
         # will force the controller to be undocumented, whereas setting it
         # within an action context will force that action to be undocumented.
@@ -90,7 +90,7 @@ module Brainstem
         #
         # Setting the +:internal+ option marks this presenter as 'internal use only',
         # and causes formatters to not display this unless documentation is generated with
-        # `--internal` flag.
+        # `--include-internal` flag.
         #
         # @param [Class] target_class the target class of the presenter (i.e the model it presents)
         # @param [Hash] options options to record with the presenter
@@ -117,7 +117,7 @@ module Brainstem
         # Setting the +:internal+ option marks this title as 'internal use only',
         # and causes formatters to fall back to the controller constant or to
         # the action name as appropriate unless documentation is generated with
-        # `--internal` flag. If you are trying to set the entire
+        # `--include-internal` flag. If you are trying to set the entire
         # controller or action as nondocumentable unless internal, instead,
         # use the +.internal!+ method in the desired context without a block.
         #
@@ -138,7 +138,7 @@ module Brainstem
         #
         # Setting the +:internal+ option marks this description as 'internal use
         # only', and causes formatters not to display a description unless documentation
-        # is generated with `--internal` flag.
+        # is generated with `--include-internal` flag.
         #
         # @param [String] text The description to set
         # @param [Hash] options options to record with the description

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -65,8 +65,8 @@ module Brainstem
         # whereas setting it within an action context will force that action to
         # be undocumented.
         #
-        def nodoc!(_description = nil)
-          configuration[brainstem_params_context][:nodoc] = true
+        def nodoc!(description = true)
+          configuration[brainstem_params_context][:nodoc] = description
         end
 
         #
@@ -75,8 +75,8 @@ module Brainstem
         # will force the controller to be undocumented, whereas setting it
         # within an action context will force that action to be undocumented.
         #
-        def internal!(_description = nil)
-          configuration[brainstem_params_context][:internal] = true
+        def internal!(description = true)
+          configuration[brainstem_params_context][:internal] = description
         end
 
         #

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -65,7 +65,7 @@ module Brainstem
         # whereas setting it within an action context will force that action to
         # be undocumented.
         #
-        def nodoc!
+        def nodoc!(_description = nil)
           configuration[brainstem_params_context][:nodoc] = true
         end
 
@@ -75,7 +75,7 @@ module Brainstem
         # will force the controller to be undocumented, whereas setting it
         # within an action context will force that action to be undocumented.
         #
-        def internal!
+        def internal!(_description = nil)
           configuration[brainstem_params_context][:internal] = true
         end
 

--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -70,6 +70,16 @@ module Brainstem
         end
 
         #
+        # Specifies that the scope should not be documented unless the `--internal`
+        # flag is passed in the CLI. Setting this on the default context
+        # will force the controller to be undocumented, whereas setting it
+        # within an action context will force that action to be undocumented.
+        #
+        def internal!
+          configuration[brainstem_params_context][:internal] = true
+        end
+
+        #
         # Specifies which presenter is used for the controller / action.
         # By default, expects presentation on all methods, and falls back to the
         # class derived from +brainstem_model_name+ if a name is not
@@ -78,11 +88,15 @@ module Brainstem
         # Setting the +:nodoc+ option marks this presenter as 'internal use only',
         # and causes formatters to display this as not indicated.
         #
+        # Setting the +:internal+ option marks this presenter as 'internal use only',
+        # and causes formatters to not display this unless documentation is generated with
+        # `--internal` flag.
+        #
         # @param [Class] target_class the target class of the presenter (i.e the model it presents)
         # @param [Hash] options options to record with the presenter
         # @option options [Boolean] :nodoc whether this presenter should not be output in the documentation.
         #
-        def presents(target_class = :default, options = { nodoc: false })
+        def presents(target_class = :default, options = { nodoc: false, internal: false })
           raise "`presents` must be a class (in #{self.to_s})" \
             unless target_class.is_a?(Class) || target_class == :default || target_class.nil?
 
@@ -100,11 +114,18 @@ module Brainstem
         # controller or action as nondocumentable, instead, use the
         # +.nodoc!+ method in the desired context without a block.
         #
+        # Setting the +:internal+ option marks this title as 'internal use only',
+        # and causes formatters to fall back to the controller constant or to
+        # the action name as appropriate unless documentation is generated with
+        # `--internal` flag. If you are trying to set the entire
+        # controller or action as nondocumentable unless internal, instead,
+        # use the +.internal!+ method in the desired context without a block.
+        #
         # @param [String] text The title to set
         # @param [Hash] options options to record with the title
         # @option options [Boolean] :nodoc whether this title should not be output in the documentation.
         #
-        def title(text, options = { nodoc: false })
+        def title(text, options = { nodoc: false, internal: false })
           configuration[brainstem_params_context][:title] = options.merge(info: text)
         end
 
@@ -115,11 +136,15 @@ module Brainstem
         # Setting the +:nodoc+ option marks this description as 'internal use
         # only', and causes formatters not to display a description.
         #
+        # Setting the +:internal+ option marks this description as 'internal use
+        # only', and causes formatters not to display a description unless documentation
+        # is generated with `--internal` flag.
+        #
         # @param [String] text The description to set
         # @param [Hash] options options to record with the description
         # @option options [Boolean] :nodoc whether this description should not be output in the documentation.
         #
-        def description(text, options = { nodoc: false })
+        def description(text, options = { nodoc: false, internal: false })
           configuration[brainstem_params_context][:description] = options.merge(info: text)
         end
 

--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -51,6 +51,10 @@ module Brainstem
           configuration[:nodoc] = true
         end
 
+        def internal!
+          configuration[:internal] = true
+        end
+
         #
         # Temporary implementation to track controllers that have been documented.
         #

--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -39,19 +39,19 @@ module Brainstem
           AssociationsBlock.new(configuration, &block)
         end
 
-        def title(str, options = { nodoc: false })
+        def title(str, options = { nodoc: false, internal: false })
           configuration[:title] = options.merge(info: str)
         end
 
-        def description(str, options = { nodoc: false })
+        def description(str, options = { nodoc: false, internal: false })
           configuration[:description] = options.merge(info: str)
         end
 
-        def nodoc!
+        def nodoc!(_description = nil)
           configuration[:nodoc] = true
         end
 
-        def internal!
+        def internal!(_description = nil)
           configuration[:internal] = true
         end
 
@@ -113,12 +113,12 @@ module Brainstem
         # @raise [ArgumentError] if neither an order string or block is given.
         #
         def sort_order(name, *args, &block)
-          valid_options = %w(info nodoc direction)
-          options       = args.extract_options!
-                            .select { |k, v| valid_options.include?(k.to_s) }
-                            .with_indifferent_access
+          valid_options       = %w(info nodoc internal direction)
+          options             = args.extract_options!
+                                  .select { |k, v| valid_options.include?(k.to_s) }
+                                  .with_indifferent_access
           options[:direction] = true unless options.has_key?(:direction)
-          order         = args.first
+          order               = args.first
 
           raise ArgumentError, "A sort order must be given" unless block_given? || order
           configuration[:sort_orders][name] = options.merge({

--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -47,12 +47,12 @@ module Brainstem
           configuration[:description] = options.merge(info: str)
         end
 
-        def nodoc!(_description = nil)
-          configuration[:nodoc] = true
+        def nodoc!(description = true)
+          configuration[:nodoc] = description
         end
 
-        def internal!(_description = nil)
-          configuration[:internal] = true
+        def internal!(description = true)
+          configuration[:internal] = description
         end
 
         #

--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -17,8 +17,8 @@ module Brainstem
         options[:info].presence
       end
 
-      def foreign_key
-        options[:foreign_key]
+      def response_key
+        options[:response_key]
       end
 
       def polymorphic_classes

--- a/spec/brainstem/api_docs/controller_spec.rb
+++ b/spec/brainstem/api_docs/controller_spec.rb
@@ -6,7 +6,7 @@ module Brainstem
     describe Controller do
       subject       { described_class.new(atlas, options) }
       let(:atlas)   { Object.new }
-      let(:options) { {internal: internal_flag} }
+      let(:options) { {include_internal: internal_flag} }
       let(:internal_flag) { false }
 
       describe "#initialize" do

--- a/spec/brainstem/api_docs/controller_spec.rb
+++ b/spec/brainstem/api_docs/controller_spec.rb
@@ -6,7 +6,8 @@ module Brainstem
     describe Controller do
       subject       { described_class.new(atlas, options) }
       let(:atlas)   { Object.new }
-      let(:options) { {} }
+      let(:options) { {internal: internal_flag} }
+      let(:internal_flag) { false }
 
       describe "#initialize" do
         it "yields self if given a block" do
@@ -31,9 +32,10 @@ module Brainstem
         let(:default_config) { {} }
         let(:show_config)    { {} }
         let(:nodoc)          { false }
-        let(:options)        { { const: const } }
+        let(:internal)       { false }
 
         before do
+          options[:const] = const
           stub(const) do |constant|
             constant.configuration { {
               :_default => default_config,
@@ -46,11 +48,51 @@ module Brainstem
 
         describe "configuration helpers" do
           describe "#contextual_documentation" do
-            let(:default_config) { { title: { info: info, nodoc: nodoc } } }
+            let(:default_config) { { title: { info: info, nodoc: nodoc, internal: internal } } }
             let(:info)           { lorem }
 
             context "when has the key" do
               let(:key) { :title }
+
+              context "when internal flag is true" do
+                let(:internal_flag) { true }
+
+                context "when contextual key is internal" do
+                  let(:internal) { true }
+
+                  it "is truthy" do
+                    expect(subject.contextual_documentation(key)).to be_truthy
+                  end
+                end
+
+                context "when contextual key is not internal" do
+                  let(:internal) { false }
+
+                  it "is truthy" do
+                    expect(subject.contextual_documentation(key)).to be_truthy
+                  end
+                end
+              end
+
+              context "when internal flag is false" do
+                let(:internal_flag) { false }
+
+                context "when contextual key is internal" do
+                  let(:internal) { true }
+
+                  it "is falsey" do
+                    expect(subject.contextual_documentation(key)).to be_falsey
+                  end
+                end
+
+                context "when contextual key is not internal" do
+                  let(:internal) { false }
+
+                  it "is truthy" do
+                    expect(subject.contextual_documentation(key)).to be_truthy
+                  end
+                end
+              end
 
               context "when not nodoc" do
                 context "when has info" do
@@ -141,7 +183,7 @@ module Brainstem
 
         describe "#title" do
           context "when present" do
-            let(:default_config) { { title: { info: lorem, nodoc: nodoc } } }
+            let(:default_config) { { title: { info: lorem, nodoc: nodoc, internal: internal } } }
 
             context "when nodoc" do
               let(:nodoc) { true }
@@ -156,6 +198,46 @@ module Brainstem
                 expect(subject.title).to eq lorem
               end
             end
+
+            context "when internal flag is true" do
+              let(:internal_flag) { true }
+
+              context "when title is internal" do
+                let(:internal) { true }
+
+                it "shows the title" do
+                  expect(subject.title).to eq lorem
+                end
+              end
+
+              context "when title is not internal" do
+                let(:internal) { false }
+
+                it "shows the title" do
+                  expect(subject.title).to eq lorem
+                end
+              end
+            end
+
+            context "when internal flag is false" do
+              let(:internal_flag) { false }
+
+              context "when title is internal" do
+                let(:internal) { true }
+
+                it "falls back to the controller class" do
+                  expect(subject.title).to eq "ClassName"
+                end
+              end
+
+              context "when title is not internal" do
+                let(:internal) { false }
+
+                it "shows the title" do
+                  expect(subject.title).to eq lorem
+                end
+              end
+            end
           end
 
           context "when absent" do
@@ -167,7 +249,7 @@ module Brainstem
 
         describe "#description" do
           context "when present" do
-            let(:default_config) { { description: { info: lorem, nodoc: nodoc } } }
+            let(:default_config) { { description: { info: lorem, nodoc: nodoc, internal: internal } } }
 
             context "when nodoc" do
               let(:nodoc) { true }
@@ -180,6 +262,46 @@ module Brainstem
             context "when documentable" do
               it "shows the description" do
                 expect(subject.description).to eq lorem
+              end
+            end
+
+            context "when internal flag is true" do
+              let(:internal_flag) { true }
+
+              context "when description is internal" do
+                let(:internal) { true }
+
+                it "shows the description" do
+                  expect(subject.description).to eq lorem
+                end
+              end
+
+              context "when description is not internal" do
+                let(:internal) { false }
+
+                it "shows the description" do
+                  expect(subject.description).to eq lorem
+                end
+              end
+            end
+
+            context "when internal flag is false" do
+              let(:internal_flag) { false }
+
+              context "when description is internal" do
+                let(:internal) { true }
+
+                it "shows nothing" do
+                  expect(subject.description).to eq ""
+                end
+              end
+
+              context "when description is not internal" do
+                let(:internal) { false }
+
+                it "shows the description" do
+                  expect(subject.description).to eq lorem
+                end
               end
             end
           end

--- a/spec/brainstem/api_docs/endpoint_spec.rb
+++ b/spec/brainstem/api_docs/endpoint_spec.rb
@@ -6,7 +6,7 @@ module Brainstem
     describe Endpoint do
       let(:lorem) { "lorem ipsum dolor sit amet" }
       let(:atlas) { Object.new }
-      let(:options) { { internal: internal_flag } }
+      let(:options) { { include_internal: internal_flag } }
       let(:internal_flag) { false }
       subject { described_class.new(atlas, options) }
 

--- a/spec/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/open_api_specification/version_2/presenter_formatter_spec.rb
@@ -155,7 +155,7 @@ module Brainstem
                         type: :belongs_to
 
                       association :user, User,
-                        foreign_key: :user_id,
+                        response_key: :user_id,
                         type: :has_one
                     end
                   end
@@ -165,8 +165,8 @@ module Brainstem
 
                     expect(subject.definition).to have_key :properties
                     expect(subject.definition[:properties]).to eq({
-                      'task_id' => { 'type' => 'integer', 'format' => 'int32', 'description' => '`task_id` will only be included in the response if `task` is in the list of included associations.' },
-                      'user_id' => { 'type' => 'integer', 'format' => 'int32', 'description' => '`user_id` will only be included in the response if `user` is in the list of included associations.' }
+                      'task_id' => { 'type' => 'string', 'description' => "`task_id` will only be included in the response if `task` is in the list of included associations. See <a href='#section/Includes'>include</a> section for usage." },
+                      'user_id' => { 'type' => 'string', 'description' => "`user_id` will only be included in the response if `user` is in the list of included associations. See <a href='#section/Includes'>include</a> section for usage." }
                     })
                   end
                 end
@@ -186,10 +186,9 @@ module Brainstem
                     expect(subject.definition[:properties]).to eq({
                       'task_ids' => {
                         'type' => 'array',
-                        'description' => '`task_ids` will only be included in the response if `task` is in the list of included associations.',
+                        'description' => "`task_ids` will only be included in the response if `task` is in the list of included associations. See <a href='#section/Includes'>include</a> section for usage.",
                         'items' => {
-                          'type' => 'integer',
-                          'format' => 'int32'
+                          'type' => 'string'
                         },
                       },
                     })
@@ -210,7 +209,7 @@ module Brainstem
                     expect(subject.definition[:properties]).to eq({
                       'task_ref' => {
                         'type' => 'object',
-                        'description' => '`task_ref` will only be included in the response if `task` is in the list of included associations.',
+                        'description' => "`task_ref` will only be included in the response if `task` is in the list of included associations. See <a href='#section/Includes'>include</a> section for usage.",
                         'properties' => {
                           'id' => {
                             'type' => 'string'
@@ -244,7 +243,6 @@ module Brainstem
                         'sprockets' => {
                           'type' => 'object',
                           'properties' => {
-
                             'sprocket_name' => { 'type' => 'string', 'description' => 'Whatever.' }
                           }
                         }
@@ -500,6 +498,40 @@ module Brainstem
 
                   expect(subject.definition[:properties]).to be_nil
                 end
+              end
+            end
+
+            describe '#sort_properties!' do
+              let(:presenter_class) do
+                Class.new(Brainstem::Presenter) do
+                  presents Workspace
+                end
+              end
+              let(:presenter) { Presenter.new(Object.new, const: presenter_class, target_class: 'Workspace') }
+              let(:conditionals) { {} }
+
+              before do
+                stub(presenter).conditionals { conditionals }
+
+                presenter_class.associations do
+                  association :user, User,
+                    response_key: :user_id,
+                    type: :has_one
+
+                  association :task, Task,
+                    type: :belongs_to
+                end
+              end
+
+              it 'correctly sorts the properties' do
+                subject.send(:format_fields!)
+                subject.send(:sort_properties!)
+
+                expect(subject.definition).to have_key :properties
+                expect(subject.definition[:properties]).to eq({
+                  'task_id' => { 'type' => 'string', 'description' => "`task_id` will only be included in the response if `task` is in the list of included associations. See <a href='#section/Includes'>include</a> section for usage." },
+                  'user_id' => { 'type' => 'string', 'description' => "`user_id` will only be included in the response if `user` is in the list of included associations. See <a href='#section/Includes'>include</a> section for usage." }
+                })
               end
             end
           end

--- a/spec/brainstem/api_docs/presenter_spec.rb
+++ b/spec/brainstem/api_docs/presenter_spec.rb
@@ -9,10 +9,12 @@ module Brainstem
     describe Presenter do
       subject { described_class.new(atlas, options) }
 
-      let(:atlas)        { Object.new }
-      let(:target_class) { Class.new }
-      let(:options)      { { } }
-      let(:nodoc)        { false }
+      let(:atlas)         { Object.new }
+      let(:target_class)  { Class.new }
+      let(:options)       { { internal: internal_flag } }
+      let(:internal_flag) { false }
+      let(:nodoc)         { false }
+      let(:internal)      { false }
 
       describe "#initialize" do
         it "yields self if given a block" do
@@ -25,7 +27,6 @@ module Brainstem
         let(:lorem)  { "lorem ipsum dolor sit amet" }
         let(:const)  { Object.new }
         let(:config) { {} }
-        let(:options)   { { const: const } }
 
         subject { described_class.new(atlas, options) }
 
@@ -35,16 +36,58 @@ module Brainstem
             constant.to_s { "Namespaced::ClassName" }
             constant.possible_brainstem_keys { Set.new(%w(lorem ipsum)) }
           end
+
+          options[:const] = const
         end
 
         describe "#nodoc?" do
-          let(:config) { { nodoc: nodoc } }
+          let(:config) { { nodoc: nodoc, internal: internal } }
 
           context "when nodoc in default" do
             let(:nodoc) { true }
 
             it "is true" do
               expect(subject.nodoc?).to eq true
+            end
+          end
+
+          context "when internal flag is true" do
+            let(:internal_flag) { true }
+
+            context "when action config is internal" do
+              let(:internal) { true }
+
+              it "is false" do
+                expect(subject.nodoc?).to eq false
+              end
+            end
+
+            context "when action config is not internal" do
+              let(:internal) { false }
+
+              it "is false" do
+                expect(subject.nodoc?).to eq false
+              end
+            end
+          end
+
+          context "when internal flag is false" do
+            let(:internal_flag) { false }
+
+            context "when action config is internal" do
+              let(:internal) { true }
+
+              it "is true" do
+                expect(subject.nodoc?).to eq true
+              end
+            end
+
+            context "when action config is not internal" do
+              let(:internal) { false }
+
+              it "is false" do
+                expect(subject.nodoc?).to eq false
+              end
             end
           end
 
@@ -56,13 +99,53 @@ module Brainstem
         end
 
         describe "#title" do
-          let(:config) { { title: { info: lorem, nodoc: nodoc } } }
+          let(:config) { { title: { info: lorem, nodoc: nodoc, internal: internal } } }
 
           context "when nodoc" do
             let(:nodoc) { true }
 
             it "uses the last portion of the presenter's class" do
               expect(subject.title).to eq "ClassName"
+            end
+          end
+
+          context "when internal flag is true" do
+            let(:internal_flag) { true }
+
+            context "when title is internal" do
+              let(:internal) { true }
+
+              it "shows the title" do
+                expect(subject.title).to eq lorem
+              end
+            end
+
+            context "when title is not internal" do
+              let(:internal) { false }
+
+              it "shows the title" do
+                expect(subject.title).to eq lorem
+              end
+            end
+          end
+
+          context "when internal flag is false" do
+            let(:internal_flag) { false }
+
+            context "when title is internal" do
+              let(:internal) { true }
+
+              it "uses the last portion of the presenter's class" do
+                expect(subject.title).to eq "ClassName"
+              end
+            end
+
+            context "when title is not internal" do
+              let(:internal) { false }
+
+              it "shows the title" do
+                expect(subject.title).to eq lorem
+              end
             end
           end
 
@@ -81,7 +164,47 @@ module Brainstem
 
         describe "#description" do
           context "with description" do
-            let(:config) { { description: { info: lorem, nodoc: nodoc } } }
+            let(:config) { { description: { info: lorem, nodoc: nodoc, internal: internal } } }
+
+            context "when internal flag is true" do
+              let(:internal_flag) { true }
+
+              context "when description is internal" do
+                let(:internal) { true }
+
+                it "shows the description" do
+                  expect(subject.description).to eq lorem
+                end
+              end
+
+              context "when description is not internal" do
+                let(:internal) { false }
+
+                it "shows the description" do
+                  expect(subject.description).to eq lorem
+                end
+              end
+            end
+
+            context "when internal flag is false" do
+              let(:internal_flag) { false }
+
+              context "when description is internal" do
+                let(:internal) { true }
+
+                it "shows nothing" do
+                  expect(subject.description).to eq ""
+                end
+              end
+
+              context "when description is not internal" do
+                let(:internal) { false }
+
+                it "shows the description" do
+                  expect(subject.description).to eq lorem
+                end
+              end
+            end
 
             context "when nodoc" do
               let(:nodoc) { true }
@@ -112,13 +235,77 @@ module Brainstem
             end
           end
 
-          subject { described_class.new(atlas, target_class: 'Workspace', const: presenter_class) }
+          subject { described_class.new(atlas, options) }
 
           before do
             stub(atlas).find_by_class(anything) { nil }
+            options[:target_class] = 'Workspace'
+            options[:const] = presenter_class
           end
 
           describe "leafs" do
+            context "when internal flag is true" do
+              let(:internal_flag) { true }
+
+              context "when field is internal" do
+                before do
+                  presenter_class.fields do
+                    field :new_field, :string, dynamic: lambda { "new_field value" }, nodoc: false
+                    field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: true
+                    field :new_field3, :string, dynamic: lambda { "new_field3 value" }
+                  end
+                end
+
+                it "keeps the field" do
+                  expect(subject.valid_fields.keys).to match_array(%w(new_field new_field2 new_field3))
+                end
+              end
+
+              context "when field is not internal" do
+                before do
+                  presenter_class.fields do
+                    field :new_field, :string, dynamic: lambda { "new_field value" }, nodoc: false
+                    field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: false
+                    field :new_field3, :string, dynamic: lambda { "new_field3 value" }
+                  end
+                end
+
+                it "keeps the field" do
+                  expect(subject.valid_fields.keys).to match_array(%w(new_field new_field2 new_field3))
+                end
+              end
+            end
+
+            context "when internal flag is false" do
+              let(:internal_flag) { false }
+
+              context "when field is internal" do
+                before do
+                  presenter_class.fields do
+                    field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: true
+                  end
+                end
+
+                it "rejects the field" do
+                  expect(subject.valid_fields.count).to eq 0
+                end
+              end
+
+              context "when field is not internal" do
+                before do
+                  presenter_class.fields do
+                    field :new_field, :string, dynamic: lambda { "new_field value" }, nodoc: true
+                    field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: false
+                    field :new_field3, :string, dynamic: lambda { "new_field3 value" }
+                  end
+                end
+
+                it "keeps the field" do
+                  expect(subject.valid_fields.keys).to match_array(%w(new_field2 new_field3))
+                end
+              end
+            end
+
             context "when nodoc" do
               before do
                 presenter_class.fields do
@@ -243,6 +430,7 @@ module Brainstem
                 field :mandatory_field, :string, dynamic: lambda { "new_field value" }
                 field :optional_top_field, :string, dynamic: lambda { "new_field value" }, optional: true
                 field :nodoc_optional_top_field, :string, dynamic: lambda { "new_field value" }, optional: true, nodoc: true
+                field :internal_optional_top_field, :string, dynamic: lambda { "new_field value" }, optional: true, internal: true
 
                 fields :optional_block_field, :hash, optional: true do
                   field :leaf_field_1, :string
@@ -256,6 +444,14 @@ module Brainstem
                   field :optional_field_nodoc_block_field, :string, optional: true
                 end
 
+                fields :internal_optional_block_field, :hash, internal: true, optional: true do
+                  field :optional_field_internal_block_field, :string, optional: true
+                end
+
+                fields :internal_block_field, :hash, internal: true do
+                  field :optional_field_internal_block_field, :string, optional: true
+                end
+
                 fields :block_field_with_optional_fields, :hash do
                   fields :optional_double_nested_field, :hash, optional: true do
                     field :leaf_field_3, :string
@@ -263,6 +459,8 @@ module Brainstem
 
                   fields :double_nested_field, :hash do
                     field :leaf_field_4, :string
+                    field :internal_optional_leaf_field, :string, internal: true, optional: true
+                    field :internal_leaf_field, :string, internal: true
                     field :optional_leaf_field, :string, optional: true
                     field :nodoc_optional_leaf_field, :string, optional: true, nodoc: true
                   end
@@ -271,25 +469,45 @@ module Brainstem
             end
           end
 
-          subject { described_class.new(atlas, target_class: 'Workspace', const: presenter_class).optional_field_names }
+          subject { described_class.new(atlas, options).optional_field_names }
 
           before do
             stub(atlas).find_by_class(anything) { nil }
+            options[:target_class] = 'Workspace'
+            options[:const] = presenter_class
           end
 
           it 'includes optional top level fields if nodoc is false' do
             expect(subject).to include('optional_top_field')
-            expect(subject).to_not include('nodoc_optional_top_field')
+            expect(subject).to_not include('nodoc_optional_top_field', 'internal_optional_top_field')
           end
 
           it 'includes optional block fields if nodoc is false' do
             expect(subject).to include('optional_block_field', 'optional_double_nested_field')
-            expect(subject).to_not include('nodoc_optional_block_field')
+            expect(subject).to_not include('nodoc_optional_block_field', 'internal_block_field')
           end
 
           it 'includes optional leaf fields of block fields if nodoc is false' do
             expect(subject).to include('optional_leaf_field')
-            expect(subject).to_not include('nodoc_optional_leaf_field', 'optional_field_nodoc_block_field')
+            expect(subject).to_not include('nodoc_optional_leaf_field', 'optional_field_nodoc_block_field', 'internal_leaf_field')
+          end
+
+          context "when internal flag is true" do
+            let(:internal_flag) { true }
+
+            it 'includes optional top level fields' do
+              expect(subject).to include('internal_optional_top_field')
+            end
+
+            it 'includes optional block fields' do
+              expect(subject).to include('internal_optional_block_field')
+              expect(subject).to_not include('internal_block_field')
+            end
+
+            it 'includes optional leaf fields of block fields' do
+              expect(subject).to include('internal_optional_leaf_field')
+              expect(subject).to_not include('internal_leaf_field')
+            end
           end
         end
 
@@ -320,8 +538,47 @@ module Brainstem
         end
 
         describe "#documentable_filter?" do
-          let(:info)   { lorem }
-          let(:filter) { { nodoc: nodoc, info: info } }
+          let(:info) { lorem }
+          let(:filter) { { nodoc: nodoc, info: info, internal: internal } }
+
+          context "when internal flag is true" do
+            let(:internal_flag) { true }
+
+            context "when field is internal" do
+              let(:internal) { true }
+
+              it "is true" do
+                expect(subject.documentable_filter?(:filter, filter)).to eq true
+              end
+            end
+
+            context "when field is not internal" do
+              let(:internal) { false }
+
+              it "is true" do
+                expect(subject.documentable_filter?(:filter, filter)).to eq true
+              end
+            end
+          end
+
+          context "when internal flag is false" do
+            let(:internal_flag) { false }
+
+            context "when field is internal" do
+              let(:internal) { true }
+
+              it "is false" do
+                expect(subject.documentable_filter?(:filter, filter)).to eq false
+              end
+            end
+
+            context "when field is not internal" do
+              let(:internal) { false }
+              it "is true" do
+                expect(subject.documentable_filter?(:filter, filter)).to eq true
+              end
+            end
+          end
 
           context "when nodoc" do
             let(:nodoc) { true }
@@ -361,11 +618,55 @@ module Brainstem
         end
 
         describe "#valid_sort_orders" do
-          let(:config) { { sort_orders: { title: { nodoc: true }, date: {} } } }
+          let(:config) { { sort_orders: { title: { nodoc: nodoc, internal: internal }, date: {} } } }
 
-          it "returns all pairs not marked nodoc" do
-            expect(subject.valid_sort_orders).to have_key(:date)
-            expect(subject.valid_sort_orders).not_to have_key(:title)
+          context 'nodoc is true' do
+            let(:nodoc) { true }
+
+            it "returns all pairs not marked nodoc" do
+              expect(subject.valid_sort_orders).to have_key(:date)
+              expect(subject.valid_sort_orders).not_to have_key(:title)
+            end
+          end
+
+          context "when internal flag is true" do
+            let(:internal_flag) { true }
+
+            context "when field is internal" do
+              let(:internal) { true }
+
+              it "returns all pairs marked internal" do
+                expect(subject.valid_sort_orders).to have_key(:title)
+              end
+            end
+
+            context "when field is not internal" do
+              let(:internal) { false }
+
+              it "returns all pairs not marked internal" do
+                expect(subject.valid_sort_orders).to have_key(:title)
+              end
+            end
+          end
+
+          context "when internal flag is false" do
+            let(:internal_flag) { false }
+
+            context "when field is internal" do
+              let(:internal) { true }
+
+              it "doesnt return all pairs not marked internal" do
+                expect(subject.valid_sort_orders).to_not have_key(:title)
+              end
+            end
+
+            context "when field is not internal" do
+              let(:internal) { false }
+
+              it "returns all pairs not marked internal" do
+                expect(subject.valid_sort_orders).to have_key(:title)
+              end
+            end
           end
         end
 
@@ -396,8 +697,48 @@ module Brainstem
         end
 
         describe "#documentable_association?" do
-          let(:desc)        { lorem }
-          let(:association) { OpenStruct.new(options: { nodoc: nodoc }, description: desc ) }
+          let(:desc) { lorem }
+          let(:association) { OpenStruct.new(options: { nodoc: nodoc, internal: internal }, description: desc) }
+
+          context "when internal flag is true" do
+            let(:internal_flag) { true }
+
+            context "when field is internal" do
+              let(:internal) { true }
+
+              it "is true" do
+                expect(subject.documentable_association?(:assoc, association)).to eq true
+              end
+            end
+
+            context "when field is not internal" do
+              let(:internal) { false }
+
+              it "is true" do
+                expect(subject.documentable_association?(:assoc, association)).to eq true
+              end
+            end
+          end
+
+          context "when internal flag is false" do
+            let(:internal_flag) { false }
+
+            context "when field is internal" do
+              let(:internal) { true }
+
+              it "is false" do
+                expect(subject.documentable_association?(:assoc, association)).to eq false
+              end
+            end
+
+            context "when field is not internal" do
+              let(:internal) { false }
+
+              it "is true" do
+                expect(subject.documentable_association?(:assoc, association)).to eq true
+              end
+            end
+          end
 
           context "when nodoc" do
             let(:nodoc) { true }
@@ -485,7 +826,7 @@ module Brainstem
         end
 
         describe "#contextual_documentation" do
-          let(:config) { { title: { info: info, nodoc: nodoc } } }
+          let(:config) { { title: { info: info, nodoc: nodoc, internal: internal } } }
           let(:info)   { lorem }
 
           context "when has the key" do
@@ -507,6 +848,46 @@ module Brainstem
 
                 it "is falsey" do
                   expect(subject.contextual_documentation(key)).to be_falsey
+                end
+              end
+            end
+
+            context "when internal flag is true" do
+              let(:internal_flag) { true }
+
+              context "when field is internal" do
+                let(:internal) { true }
+
+                it "is truthy" do
+                  expect(subject.contextual_documentation(key)).to be_truthy
+                end
+              end
+
+              context "when field is not internal" do
+                let(:internal) { false }
+
+                it "is truthy" do
+                  expect(subject.contextual_documentation(key)).to be_truthy
+                end
+              end
+            end
+
+            context "when internal flag is false" do
+              let(:internal_flag) { false }
+
+              context "when field is internal" do
+                let(:internal) { true }
+
+                it "is falsey" do
+                  expect(subject.contextual_documentation(key)).to be_falsey
+                end
+              end
+
+              context "when field is not internal" do
+                let(:internal) { false }
+
+                it "is truthy" do
+                  expect(subject.contextual_documentation(key)).to be_truthy
                 end
               end
             end
@@ -592,7 +973,7 @@ module Brainstem
             stub(presenter).nodoc? { nodoc }
           end
 
-          context "when nodoc" do
+          context "when nodoc? returns true" do
             let(:nodoc) { true }
 
             it "is nil" do
@@ -600,7 +981,7 @@ module Brainstem
             end
           end
 
-          context "when not nodoc" do
+          context "when nodoc? returns false" do
             it "is the path" do
               expect(subject.link_for_association(association)).to eq "./path"
             end

--- a/spec/brainstem/api_docs/presenter_spec.rb
+++ b/spec/brainstem/api_docs/presenter_spec.rb
@@ -251,7 +251,7 @@ module Brainstem
                 before do
                   presenter_class.fields do
                     field :new_field, :string, dynamic: lambda { "new_field value" }, nodoc: false
-                    field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: true
+                    field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: 'Only for internal docs'
                     field :new_field3, :string, dynamic: lambda { "new_field3 value" }
                   end
                 end
@@ -283,6 +283,7 @@ module Brainstem
                 before do
                   presenter_class.fields do
                     field :new_field2, :string, dynamic: lambda { "new_field2 value" }, internal: true
+                    field :new_field3, :string, dynamic: lambda { "new_field3 value" }, internal: 'Only for internal docs'
                   end
                 end
 
@@ -444,7 +445,7 @@ module Brainstem
                   field :optional_field_nodoc_block_field, :string, optional: true
                 end
 
-                fields :internal_optional_block_field, :hash, internal: true, optional: true do
+                fields :internal_optional_block_field, :hash, internal: 'Only for internal docs', optional: true do
                   field :optional_field_internal_block_field, :string, optional: true
                 end
 
@@ -459,7 +460,7 @@ module Brainstem
 
                   fields :double_nested_field, :hash do
                     field :leaf_field_4, :string
-                    field :internal_optional_leaf_field, :string, internal: true, optional: true
+                    field :internal_optional_leaf_field, :string, internal: 'Only for internal docs', optional: true
                     field :internal_leaf_field, :string, internal: true
                     field :optional_leaf_field, :string, optional: true
                     field :nodoc_optional_leaf_field, :string, optional: true, nodoc: true

--- a/spec/brainstem/api_docs/presenter_spec.rb
+++ b/spec/brainstem/api_docs/presenter_spec.rb
@@ -11,7 +11,7 @@ module Brainstem
 
       let(:atlas)         { Object.new }
       let(:target_class)  { Class.new }
-      let(:options)       { { internal: internal_flag } }
+      let(:options)       { { include_internal: internal_flag } }
       let(:internal_flag) { false }
       let(:nodoc)         { false }
       let(:internal)      { false }

--- a/spec/brainstem/cli/generate_api_docs_command_spec.rb
+++ b/spec/brainstem/cli/generate_api_docs_command_spec.rb
@@ -123,7 +123,7 @@ module Brainstem
           let(:args) { %w(--include-internal) }
 
           it "sets the internal option in the args for atlas" do
-            expect(subject.options[:builder][:args_for_atlas][:internal]).to eq true
+            expect(subject.options[:builder][:args_for_atlas][:include_internal]).to eq true
           end
         end
 

--- a/spec/brainstem/cli/generate_api_docs_command_spec.rb
+++ b/spec/brainstem/cli/generate_api_docs_command_spec.rb
@@ -119,6 +119,14 @@ module Brainstem
           end
         end
 
+        context "when --include-internal" do
+          let(:args) { %w(--include-internal) }
+
+          it "sets the internal option in the args for atlas" do
+            expect(subject.options[:builder][:args_for_atlas][:internal]).to eq true
+          end
+        end
+
         context "when --oas-filename-pattern" do
           let(:args) { %w(--oas-filename-pattern=blah/{{version}}.{{extension}}) }
 

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -22,6 +22,16 @@ module Brainstem
         end
       end
 
+      describe ".internal!" do
+        it "sets the config nodoc to true" do
+          subject.brainstem_params do
+            internal!
+          end
+
+          expect(subject.configuration[:_default][:internal]).to eq true
+        end
+      end
+
       describe ".brainstem_params" do
         it "evaluates the given block in the class context" do
           mock(subject).configuration

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -15,7 +15,7 @@ module Brainstem
       describe ".nodoc!" do
         it "sets the config nodoc to true" do
           subject.brainstem_params do
-            nodoc!
+            nodoc! "Description for why these are nodoc"
           end
 
           expect(subject.configuration[:_default][:nodoc]).to eq true
@@ -23,9 +23,9 @@ module Brainstem
       end
 
       describe ".internal!" do
-        it "sets the config nodoc to true" do
+        it "sets the config internal to true" do
           subject.brainstem_params do
-            internal!
+            internal! "Description for why these are internal docs"
           end
 
           expect(subject.configuration[:_default][:internal]).to eq true

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -13,9 +13,17 @@ module Brainstem
       end
 
       describe ".nodoc!" do
-        it "sets the config nodoc to true" do
+        it "sets the config nodoc to passed in description" do
           subject.brainstem_params do
             nodoc! "Description for why these are nodoc"
+          end
+
+          expect(subject.configuration[:_default][:nodoc]).to eq "Description for why these are nodoc"
+        end
+
+        it "sets the config nodoc to default value (true)" do
+          subject.brainstem_params do
+            nodoc!
           end
 
           expect(subject.configuration[:_default][:nodoc]).to eq true
@@ -23,9 +31,17 @@ module Brainstem
       end
 
       describe ".internal!" do
-        it "sets the config internal to true" do
+        it "sets the config internal to passed in description" do
           subject.brainstem_params do
             internal! "Description for why these are internal docs"
+          end
+
+          expect(subject.configuration[:_default][:internal]).to eq "Description for why these are internal docs"
+        end
+
+        it "sets the config internal to default value (true)" do
+          subject.brainstem_params do
+            internal!
           end
 
           expect(subject.configuration[:_default][:internal]).to eq true

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -134,6 +134,16 @@ describe Brainstem::Concerns::PresenterDSL do
     end
   end
 
+  describe 'the internal! method' do
+    before do
+      presenter_class.internal!
+    end
+
+    it "is stored in the configuration" do
+      expect(presenter_class.configuration[:internal]).to be true
+    end
+  end
+
   # sort_order :created_at, ".created_at"
   describe 'the sort_order block' do
     let(:value)   { "widgets.created_at" }

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -126,7 +126,7 @@ describe Brainstem::Concerns::PresenterDSL do
 
   describe 'the nodoc! method' do
     before do
-      presenter_class.nodoc!
+      presenter_class.nodoc! "Description for why these are nodoc"
     end
 
     it "is stored in the configuration" do
@@ -136,7 +136,7 @@ describe Brainstem::Concerns::PresenterDSL do
 
   describe 'the internal! method' do
     before do
-      presenter_class.internal!
+      presenter_class.internal! "Description for why these are internal docs"
     end
 
     it "is stored in the configuration" do

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -125,21 +125,25 @@ describe Brainstem::Concerns::PresenterDSL do
   end
 
   describe 'the nodoc! method' do
-    before do
+    it "is stored in the configuration" do
       presenter_class.nodoc! "Description for why these are nodoc"
+      expect(presenter_class.configuration[:nodoc]).to eq "Description for why these are nodoc"
     end
 
-    it "is stored in the configuration" do
+    it "is defaults to true" do
+      presenter_class.nodoc!
       expect(presenter_class.configuration[:nodoc]).to be true
     end
   end
 
   describe 'the internal! method' do
-    before do
+    it "is stored in the configuration" do
       presenter_class.internal! "Description for why these are internal docs"
+      expect(presenter_class.configuration[:internal]).to eq "Description for why these are internal docs"
     end
 
-    it "is stored in the configuration" do
+    it "is defaults to true" do
+      presenter_class.internal!
       expect(presenter_class.configuration[:internal]).to be true
     end
   end

--- a/spec/brainstem/dsl/association_spec.rb
+++ b/spec/brainstem/dsl/association_spec.rb
@@ -6,9 +6,9 @@ describe Brainstem::DSL::Association do
   let(:target_class) { User }
   let(:description) { "This object's user" }
   let(:type) { :belongs_to }
-  let(:foreign_key) { :user_id }
+  let(:response_key) { :user_id }
   let(:polymorphic_classes) { [User, Task] }
-  let(:options) { { info: description, foreign_key: foreign_key, type: type, polymorphic_classes: polymorphic_classes } }
+  let(:options) { { info: description, response_key: response_key, type: type, polymorphic_classes: polymorphic_classes } }
   let(:association) { Brainstem::DSL::Association.new(name, target_class, options) }
 
   describe '#description' do
@@ -27,18 +27,18 @@ describe Brainstem::DSL::Association do
     end
   end
 
-  describe '#foreign_key' do
-    context 'when `foreign_key` is specified in the options' do
-      it 'returns the value specified with the foreign_key key' do
-        expect(association.foreign_key).to eq(foreign_key)
+  describe '#response_key' do
+    context 'when `response_key` is specified in the options' do
+      it 'returns the value specified with the response_key key' do
+        expect(association.response_key).to eq(response_key)
       end
     end
 
-    context 'when `foreign_key` is not specified in the options' do
+    context 'when `response_key` is not specified in the options' do
       let(:options) { {} }
 
       it 'returns nil' do
-        expect(association.foreign_key).to be_nil
+        expect(association.response_key).to be_nil
       end
     end
   end


### PR DESCRIPTION
- Add ability to add an internal option to all properties
- When properties are marked as internal, docs will not be generated for them unless `--include-internal` is passed via the CLI.
- Add the ability to describe why an endpoint is marked as `internal` or `nodoc!`. 