### PR TITLE
Stake out a place for hypermedia in results section

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -125,10 +125,10 @@ module Brainstem
     def actions_for(model, key, current_user)
       {}.tap do |actions|
         if model.updatable_by?(current_user)
-          actions['update'] = { method: "put", href: "/api/v1/#{key}/#{model.id}" }
+          actions['update'] = { "method" => "put", "href" => "/api/v1/#{key}/#{model.id}" }
         end
         if model.destroyable_by?(current_user)
-          actions['delete'] = { method: "delete", href: "/api/v1/#{key}/#{model.id}" }
+          actions['delete'] = { "method" => "delete", "href" => "/api/v1/#{key}/#{model.id}" }
         end
       end
     end

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -102,7 +102,7 @@ module Brainstem
         struct['results'] = primary_models.map do |model|
           { 'key' => brainstem_key,
             'id' => model.id.to_s,
-            '_actions' => actions_for(model, options[:primary_presenter].class.merged_helper_class.new.current_user) }
+            '_actions' => actions_for(model, brainstem_key, options[:primary_presenter].class.merged_helper_class.new.current_user) }
         end
 
         associated_models.each do |association_brainstem_key, associated_models_hash|
@@ -122,13 +122,13 @@ module Brainstem
       @presenters ||= {}
     end
 
-    def actions_for(model, current_user)
+    def actions_for(model, key, current_user)
       {}.tap do |actions|
         if model.updatable_by?(current_user)
-          actions['update'] = { href: "/api/v1/something/#{model.id}" }
+          actions['update'] = { href: "/api/v1/#{key}/#{model.id}" }
         end
         if model.destroyable_by?(current_user)
-          actions['delete'] = { href: "/api/v1/something/#{model.id}" }
+          actions['delete'] = { href: "/api/v1/#{key}/#{model.id}" }
         end
       end
     end

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -125,10 +125,10 @@ module Brainstem
     def actions_for(model, key, current_user)
       {}.tap do |actions|
         if model.updatable_by?(current_user)
-          actions['update'] = { href: "/api/v1/#{key}/#{model.id}" }
+          actions['update'] = { method: "put", href: "/api/v1/#{key}/#{model.id}" }
         end
         if model.destroyable_by?(current_user)
-          actions['delete'] = { href: "/api/v1/#{key}/#{model.id}" }
+          actions['delete'] = { method: "delete", href: "/api/v1/#{key}/#{model.id}" }
         end
       end
     end


### PR DESCRIPTION
Add hypermedia information to the brainstem response. 

RFC: https://github.com/mavenlink/rfc/pull/160

TODO:

- The current_user lookup needs to be simplified to only happen once.
- Hypermedia should be optional
- Real endpoint lookup

Sample response:

```
{"count"=>1,
 "results"=>
  [{"key"=>"posts",
    "id"=>"132717776",
    "_actions"=>{"update"=>{"method"=>"put", "href"=>"/api/v1/posts/132717776"}}}],
 "posts"=>
  {"132717776"=>
    {"newest_reply_at"=>nil,
     "message"=>"hi everyone, chime in",
     "formatted_message"=>"<p>hi everyone, chime in</p>",
     "parsed_message"=>"hi everyone, chime in",
     "has_attachments"=>false,
     "created_at"=>"2019-02-28T08:19:40-08:00",
     "updated_at"=>"2019-02-28T08:19:40-08:00",
     "reply_count"=>4,
     "reply"=>false,
     "private"=>false,
     "subject_title"=>nil,
     "subject_id"=>nil,
     "subject_type"=>nil,
     "subject_ref"=>nil,
     "user_id"=>"980204181",
     "workspace_id"=>"32987382",
     "story_id"=>nil,
     "id"=>"132717776"}},
 "meta"=>{"count"=>1, "page_count"=>1, "page_number"=>1, "page_size"=>20}}
```