### PR TITLE
Prototype: process an additional param that is sent to associations

### DIFF
--- a/lib/brainstem/dsl/association.rb
+++ b/lib/brainstem/dsl/association.rb
@@ -37,12 +37,14 @@ module Brainstem
         end
       end
 
-      def run_on(model, context, helper_instance = Object.new)
+      def run_on(model, context, helper_instance = Object.new, lookup_options = {})
         if options[:lookup]
           run_on_with_lookup(model, context, helper_instance)
         elsif options[:dynamic]
           proc = options[:dynamic]
-          if proc.arity == 1
+          if proc.arity == -2
+            helper_instance.instance_exec(model, lookup_options, &proc)
+          elsif proc.arity == 1
             helper_instance.instance_exec(model, &proc)
           else
             helper_instance.instance_exec(&proc)

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -334,7 +334,9 @@ module Brainstem
         # If this association has been explictly requested, execute the association here.  Additionally, store
         # the loaded models in the :load_associations_into hash for later use.
         if context[:association_objects_by_name][external_name]
-          associated_model_or_models = association.run_on(model, context, context[:helper_instance])
+          lookup_options = {}
+          lookup_options[:firstFiftyAssociations] = true if options[:firstFiftyAssociations]
+          associated_model_or_models = association.run_on(model, context, context[:helper_instance], lookup_options)
 
           if options[:load_associations_into]
             Array(associated_model_or_models).flatten.each do |associated_model|

--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -93,10 +93,13 @@ module Brainstem
 
       if primary_models.length > 0
         associated_models = {}
+        group_present_options = {optional_fields: optional_fields, load_associations_into: associated_models}
+        if options[:params]["firstFiftyAssociations"]
+          group_present_options.merge!({firstFiftyAssociations: true})
+        end
         presented_primary_models = options[:primary_presenter].group_present(primary_models,
                                                                              selected_associations.map(&:name),
-                                                                             optional_fields: optional_fields,
-                                                                             load_associations_into: associated_models)
+                                                                             group_present_options)
 
         struct[brainstem_key] = presented_primary_models.each.with_object({}) { |model, obj| obj[model['id']] = model }
         struct['results'] = presented_primary_models.map { |model| { 'key' => brainstem_key, 'id' => model['id'] } }


### PR DESCRIPTION
# DO NOT MERGE.  MEANT FOR DISCUSSION.

Proof of concept meant to explore passing additional options to `dynamic` associations.  While this is tailored towards the placeholder "firstFiftyAssociations ", meant to address a current problem with pagination, something like this would lay the groundwork for additional options.

In the presenter, association definition goes from
```ruby
dynamic: lambda {|model| model.scope }
```
to
```ruby
dynamic: lambda {|model, options = {}| some_option_based_behavior ? model.something_else : model.scope }
```

The new param is not required to maintain backwards compatibility and leaves the responsibility of handling that option up to the association proc itself.  The procs themselves would probably end up needing to be refactored wholesale to support any new features that would be added to them, such as pagination.