### PR TITLE
Fix MySQL specs

### DIFF
--- a/spec/spec_helpers/schema.rb
+++ b/spec/spec_helpers/schema.rb
@@ -1,5 +1,5 @@
 if ENV['USE_MYSQL']
-  ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :database => 'test', :username => 'root', :password => '', :host => '127.0.0.1')
+  ActiveRecord::Base.establish_connection(:adapter => 'mysql2', :database => 'test', :username => 'root', :password => '', :host => '127.0.0.1', variables: { sql_mode: "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION" })
 else
   ActiveRecord::Base.establish_connection(:adapter => 'sqlite3', :database => ':memory:')
 end


### PR DESCRIPTION
- Brainstem implicitly relies on the ONLY_FULL_GROUP_BY
  config not being set in MySQL. Newer versions of MySQL
  have this enabled by default.

- Not sure why we would suddenly start breaking. It's possible
  the MySQL version in CI is not locked down.