### PR TITLE
Add Rails 5.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
++ **2.2.0** - _08/15/2019_
+  ### Bugfixes
+    - Add support for API documentation generation in Rails 5.x
+    - Address deprecation warnings for Rails 6 by wrapping raw sql in `Arel.sql`
+
 + **2.1.0** - _05/10/2019_
   ### New Features
     - Add the ability to mark properties as internal for Open API.

--- a/lib/brainstem/api_docs/introspectors/rails_introspector.rb
+++ b/lib/brainstem/api_docs/introspectors/rails_introspector.rb
@@ -212,17 +212,19 @@ module Brainstem
                   .classify
                   .constantize rescue nil
 
+              http_methods = (
+                route.verb.is_a?(Regexp) ?
+                  route.verb.inspect.gsub(/[\/\$\^]/, '') :
+                  route.verb
+              ).split("|")
+
               {
                 alias:            route.name,
                 path:             route.path.spec.to_s,
                 controller_name:  route.defaults[:controller],
                 controller:       controller_const,
                 action:           route.defaults[:action],
-                http_methods:     route.constraints
-                  .fetch(:request_method, nil)
-                  .inspect
-                  .gsub(/[\/\$\^]/, '')
-                  .split("|")
+                http_methods:     http_methods
               }
             end.compact
           end

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -232,7 +232,7 @@ module Brainstem
       primary_key = scope.model.primary_key
 
       if table_name && primary_key
-        "#{scope.connection.quote_table_name(table_name)}.#{scope.connection.quote_column_name(primary_key)} ASC"
+        Arel.sql("#{scope.connection.quote_table_name(table_name)}.#{scope.connection.quote_column_name(primary_key)} ASC")
       else
         nil
       end

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/spec/dummy/rails.rb
+++ b/spec/dummy/rails.rb
@@ -4,34 +4,47 @@ silence_warnings do
   FakeRailsApplication      = Struct.new(:eager_load!, :routes)
   FakeRailsRoutesObject     = Struct.new(:routes)
   FakeRailsRoutePathObject  = Struct.new(:spec)
-  FakeRailsRoute            = Struct.new(:name, :path, :defaults, :constraints)
+  FakeRailsRoute            = Struct.new(:name, :path, :defaults, :verb)
 end
 
 class Rails
   def self.application
     @application ||= begin
+      #
+      # For Rails 4.1 & 4.2, the `verb` method on a route returns a regular expression.
+      #
       route_1 = FakeRailsRoute.new(
         "fake_descendant",
         FakeRailsRoutePathObject.new(spec: '/fake_descendant'),
         { controller: "fake_descendant", action: "show" },
-        { :request_method => /^GET|POST$/ }
+        /^GET|POST$/
       )
 
       route_2 = FakeRailsRoute.new(
         "route_with_no_controller",
         FakeRailsRoutePathObject.new(spec: '/fake_descendant'),
         { },
-        { :request_method => /^PATCH$/ }
+        /^PATCH$/
       )
 
+      #
+      # For Rails 5.x, the `verb` method on a route returns a string.
+      #
       route_3 = FakeRailsRoute.new(
         "route_with_invalid_controller",
         FakeRailsRoutePathObject.new(spec: '/fake_descendant'),
         { controller: "invalid_controller", action: "show" },
-        { :request_method => /^GET$/ }
+        'GET'
       )
 
-      routes = FakeRailsRoutesObject.new([ route_1, route_2, route_3 ])
+      route_4 = FakeRailsRoute.new(
+        "another_fake_descendant",
+        FakeRailsRoutePathObject.new(spec: '/another_fake_descendant'),
+        { controller: "another_fake_descendant", action: "update" },
+        'PUT|PATCH'
+      )
+
+      routes = FakeRailsRoutesObject.new([ route_1, route_2, route_3, route_4 ])
 
       FakeRailsApplication.new(true, routes)
     end
@@ -54,14 +67,14 @@ class FakeApiEngine
         "fake_descendant",
         FakeRailsRoutePathObject.new(spec: '/fake_route_1'),
         { controller: "fake_descendant", action: "show" },
-        { :request_method => /^GET$/ }
+        /^PUT|PATCH$/
       )
 
       route_2 = FakeRailsRoute.new(
         "fake_descendant",
         FakeRailsRoutePathObject.new(spec: '/fake_route_2'),
         { controller: "fake_descendant", action: "show" },
-        { :request_method => /^GET$/ }
+        'PUT|PATCH'
       )
 
       FakeRailsRoutesObject.new([ route_1, route_2 ])


### PR DESCRIPTION
- Fetching http methods from routes in the Rails introspector has been updated to support the differences in API between Rails 4.x & 5.x
- Fix deprecation warnings for Rails 6