### PR TITLE
Add PlantUML doc format

### DIFF
--- a/lib/brainstem/api_docs/formatters/markdown/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/markdown/presenter_formatter.rb
@@ -115,6 +115,10 @@ module Brainstem
                     description = opts[:info].to_s
 
                     if opts[:items].present?
+                      unless opts[:items].is_a?(Array)
+                        raise "`:items` option needs to be an array for #{name} filter in #{presenter.target_class} presenter"
+                      end
+
                       description += "." unless description =~ /\.\s*\z/
                       description += " Available values: #{opts[:items].join(', ')}."
                     end

--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/param_definitions_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/param_definitions_formatter.rb
@@ -191,8 +191,13 @@ module Brainstem
 
               def format_query_param(param_name, param_config)
                 type_data = type_and_format(param_config[:type], param_config[:item_type])
+
                 if type_data.nil?
                   raise "Unknown Brainstem Param type encountered(#{param_config[:type]}) for param #{param_name}"
+                end
+
+                if param_config[:items].present? && !param_config[:items].is_a?(Array)
+                  raise "`:items` option needs to be an array for #{param_name} filter in #{presenter.target_class} presenter"
                 end
 
                 if param_config[:type].to_s == 'array'

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -13,16 +13,23 @@ module Brainstem
           def call
             return "" if presenter.nodoc?
 
-            buffer.puts("class " + target_class + " {")
+            open_class_definition
             format_fields
-            buffer.puts("}")
-
+            close_class_definition
             format_association_relations
 
             buffer.string
           end
 
           private
+
+          def open_class_definition
+            buffer.puts("class " + target_class + " {")
+          end
+
+          def close_class_definition
+            buffer.puts("}")
+          end
 
           attr_reader :presenter
 
@@ -41,7 +48,7 @@ module Brainstem
           end
 
           def format_association_relations
-            presenter.valid_associations.each do |name, association|
+            presenter.valid_associations.each do |_name, association|
               association_klass = association.target_class.to_s
               association_key = format_association_key(association)
 

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -22,15 +22,15 @@ module Brainstem
 
           private
 
-          def format_associations
-            buffer.puts(%(User o-- "1" Cheese)) if presenter.target_class == 'User'
-          end
-
           def buffer
             @buffer ||= StringIO.new
           end
 
           attr_reader :presenter
+
+          def format_associations
+            buffer.puts(%(User o-- "1" Cheese)) if presenter.target_class == 'User'
+          end
 
           def format_fields
             presenter.valid_fields.each do |_, field|

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -1,0 +1,42 @@
+require 'brainstem/api_docs/formatters/abstract_formatter'
+
+module Brainstem
+  module ApiDocs
+    module Formatters
+      module Puml
+        class PresenterFormatter < AbstractFormatter
+          def initialize(presenter, options = {})
+            @presenter = presenter
+            super options
+          end
+
+          def call
+            return "" if presenter.nodoc?
+
+            buffer.puts("class " + presenter.target_class + " {")
+            format_fields
+            buffer.puts("}")
+            buffer.string
+          end
+
+          private
+
+          def buffer
+            @buffer ||= StringIO.new
+          end
+
+          attr_reader :presenter
+
+          def format_fields
+            presenter.valid_fields.each do |_, field|
+              buffer.puts("#{field.type} #{field.name.to_s}")
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
+Brainstem::ApiDocs::FORMATTERS[:presenter][:puml] =
+  Brainstem::ApiDocs::Formatters::Puml::PresenterFormatter

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -13,23 +13,37 @@ module Brainstem
           def call
             return "" if presenter.nodoc?
 
-            buffer.puts("class " + presenter.target_class + " {")
+            buffer.puts("class " + target_class + " {")
             format_fields
             buffer.puts("}")
-            format_associations
+
+            format_association_relations
+
             buffer.string
           end
 
           private
 
+          attr_reader :presenter
+
           def buffer
             @buffer ||= StringIO.new
           end
 
-          attr_reader :presenter
+          def target_class
+            presenter.target_class
+          end
 
-          def format_associations
-            buffer.puts(%(User o-- "1" Cheese)) if presenter.target_class == 'User'
+          def format_association_relations
+            presenter.valid_associations.each do |name, association|
+              association_klass = association.target_class.to_s
+
+              if association.type == :has_many
+                buffer.puts(%(#{target_class} *-- "n" #{association_klass}))
+              else
+                buffer.puts(%(#{target_class} o-- "1" #{association_klass}))
+              end
+            end
           end
 
           def format_fields

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -55,7 +55,7 @@ module Brainstem
 
           def associated_connections(association)
             if association.polymorphic?
-              association.polymorphic_classes.map do |polymorphic_class|
+              Array.wrap(association.polymorphic_classes).map do |polymorphic_class|
                 connect(association, polymorphic_class, association.name)
               end
             else

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -34,22 +34,30 @@ module Brainstem
             presenter.target_class
           end
 
-          def format_association_relations
-            presenter.valid_associations.each do |name, association|
-              association_klass = association.target_class.to_s
-
-              if association.type == :has_many
-                buffer.puts(%(#{target_class} *-- "n" #{association_klass}))
-              else
-                buffer.puts(%(#{target_class} o-- "1" #{association_klass}))
-              end
-            end
-          end
-
           def format_fields
             presenter.valid_fields.each do |_, field|
               buffer.puts("#{field.type} #{field.name.to_s}")
             end
+          end
+
+          def format_association_relations
+            presenter.valid_associations.each do |name, association|
+              association_klass = association.target_class.to_s
+              association_key = format_association_key(association)
+
+              buffer.puts(%(#{target_class} #{association_connector(association)} #{association_klass} : #{association_key}))
+            end
+          end
+
+          def association_connector(association)
+            association.type == :has_many ? '*-- "n"' : 'o-- "1"'
+          end
+
+          def format_association_key(association)
+            return association.response_key if association.response_key.present?
+
+            key = association.name.singularize
+            association.type == :has_many ? "#{key}_ids" : "#{key}_id"
           end
         end
       end

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -42,8 +42,8 @@ module Brainstem
           end
 
           def format_fields
-            presenter.valid_fields.each do |_, field|
-              buffer.puts("#{field.type} #{field.name.to_s}")
+            presenter.valid_fields.sort.each do |_, field|
+              buffer.puts("#{field.type} #{field.name}")
             end
           end
 

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -49,14 +49,28 @@ module Brainstem
 
           def format_association_relations
             presenter.valid_associations.each do |_name, association|
-              association_klass = association.target_class.to_s
-              association_key = format_association_key(association)
-
-              buffer.puts(%(#{target_class} #{association_connector(association)} #{association_klass} : #{association_key}))
+              associated_connections(association).each { |connection| buffer.puts(connection) }
             end
           end
 
-          def association_connector(association)
+          def associated_connections(association)
+            if association.polymorphic?
+              association.polymorphic_classes.map do |polymorphic_class|
+                connect(association, polymorphic_class, association.name)
+              end
+            else
+              association_klass = association.target_class
+              association_key = format_association_key(association)
+
+              [connect(association, association_klass, association_key)]
+            end
+          end
+
+          def connect(association, klass, label)
+            %(#{target_class} #{connector(association)} #{klass} : #{label})
+          end
+
+          def connector(association)
             association.type == :has_many ? '*-- "n"' : 'o-- "1"'
           end
 

--- a/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/puml/presenter_formatter.rb
@@ -16,10 +16,15 @@ module Brainstem
             buffer.puts("class " + presenter.target_class + " {")
             format_fields
             buffer.puts("}")
+            format_associations
             buffer.string
           end
 
           private
+
+          def format_associations
+            buffer.puts(%(User o-- "1" Cheese)) if presenter.target_class == 'User'
+          end
 
           def buffer
             @buffer ||= StringIO.new

--- a/lib/brainstem/api_docs/sinks/abstract_sink.rb
+++ b/lib/brainstem/api_docs/sinks/abstract_sink.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'brainstem/concerns/optional'
 
 module Brainstem
@@ -17,6 +18,37 @@ module Brainstem
 
         #######################################################################$
         private
+
+        def write_path
+          @write_path ||= ::Brainstem::ApiDocs.write_path
+        end
+
+        #
+        # Defines how we write out the files.
+        #
+        def write_method
+          @write_method ||= Proc.new do |name, buff|
+            File.write(name, buff, mode: 'w')
+          end
+        end
+
+        #
+        # Asserts that a directory exists, creating it if it does not.
+        #
+        def assert_directory_exists!(path)
+          dir = File.dirname(path)
+          FileUtils.mkdir_p(dir) unless File.directory?(dir)
+        end
+
+        #
+        # Writes a given buffer to a filename within the base path.
+        #
+        def write_buffer_to_file(buffer, filename)
+          abs_path = File.join(write_path, filename)
+          assert_directory_exists!(abs_path)
+          write_method.call(abs_path, buffer)
+        end
+
         ########################################################################
 
         #

--- a/lib/brainstem/api_docs/sinks/abstract_sink.rb
+++ b/lib/brainstem/api_docs/sinks/abstract_sink.rb
@@ -46,10 +46,18 @@ module Brainstem
         # Writes a given buffer to a filename within the base path.
         #
         def write_buffer_to_file(buffer, filename)
-          abs_path = File.join(write_path, filename)
-          assert_directory_exists!(abs_path)
-          write_method.call(abs_path, buffer)
+          writer.call(buffer, filename)
         end
+
+        def writer
+          @writer ||= Proc.new do |buffer, filename|
+            abs_path = File.join(write_path, filename)
+            assert_directory_exists!(abs_path)
+            write_method.call(abs_path, buffer)
+          end
+        end
+
+        attr_writer :writer
 
         ########################################################################
 
@@ -59,7 +67,7 @@ module Brainstem
         # @return [Array<Symbol>] valid options
         #
         def valid_options
-          [ :write_method, :write_path ]
+          [ :write_method, :write_path, :writer ]
         end
       end
     end

--- a/lib/brainstem/api_docs/sinks/abstract_sink.rb
+++ b/lib/brainstem/api_docs/sinks/abstract_sink.rb
@@ -16,6 +16,8 @@ module Brainstem
           raise NotImplementedError
         end
 
+        attr_writer :write_method, :write_path
+
         #######################################################################$
         private
 
@@ -57,7 +59,7 @@ module Brainstem
         # @return [Array<Symbol>] valid options
         #
         def valid_options
-          []
+          [ :write_method, :write_path ]
         end
       end
     end

--- a/lib/brainstem/api_docs/sinks/controller_presenter_multifile_sink.rb
+++ b/lib/brainstem/api_docs/sinks/controller_presenter_multifile_sink.rb
@@ -1,5 +1,4 @@
 require 'brainstem/api_docs/sinks/abstract_sink'
-require 'fileutils'
 require 'forwardable'
 
 module Brainstem
@@ -47,36 +46,6 @@ module Brainstem
         #
         def write_presenter_files
           presenters.each_formatted_with_filename(format, &method(:write_buffer_to_file))
-        end
-
-        #
-        # Writes a given bufer to a filename within the base path.
-        #
-        def write_buffer_to_file(buffer, filename)
-          abs_path = File.join(write_path, filename)
-          assert_directory_exists!(abs_path)
-          write_method.call(abs_path, buffer)
-        end
-
-        #
-        # Asserts that a directory exists, creating it if it does not.
-        #
-        def assert_directory_exists!(path)
-          dir = File.dirname(path)
-          FileUtils.mkdir_p(dir) unless File.directory?(dir)
-        end
-
-        #
-        # Defines how we write out the files.
-        #
-        def write_method
-          @write_method ||= Proc.new do |name, buff|
-            File.write(name, buff, mode: 'w')
-          end
-        end
-
-        def write_path
-          @write_path ||= ::Brainstem::ApiDocs.write_path
         end
       end
     end

--- a/lib/brainstem/api_docs/sinks/controller_presenter_multifile_sink.rb
+++ b/lib/brainstem/api_docs/sinks/controller_presenter_multifile_sink.rb
@@ -17,11 +17,8 @@ module Brainstem
         end
 
         def valid_options
-          super | [ :write_method, :format, :write_path ]
+          super | [ :format ]
         end
-
-        attr_writer     :write_method,
-                        :write_path
 
         attr_accessor   :atlas,
                         :format

--- a/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
+++ b/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
@@ -1,7 +1,6 @@
 require 'brainstem/api_docs'
 require 'brainstem/api_docs/formatters/open_api_specification/helper'
 require 'brainstem/api_docs/sinks/abstract_sink'
-require 'fileutils'
 require 'forwardable'
 
 module Brainstem
@@ -163,11 +162,7 @@ module Brainstem
         # Writes a given bufer to a filename within the base path.
         #
         def write_spec_to_file!
-          formatted_output = format_output(output, extension)
-          abs_path         = File.join(write_path, suggested_filename)
-
-          assert_directory_exists!(abs_path)
-          write_method.call(abs_path, formatted_output)
+          write_buffer_to_file(format_output(output, extension), suggested_filename)
         end
 
         #
@@ -180,30 +175,6 @@ module Brainstem
 
           data = output.to_hash
           requested_format == 'json' ? data.to_json : data.to_yaml
-        end
-
-        #
-        # Asserts that a directory exists, creating it if it does not.
-        #
-        def assert_directory_exists!(path)
-          dir = File.dirname(path)
-          FileUtils.mkdir_p(dir) unless File.directory?(dir)
-        end
-
-        #
-        # Defines how we write out the files.
-        #
-        def write_method
-          @write_method ||= Proc.new do |name, buff|
-            File.write(name, buff, mode: 'w')
-          end
-        end
-
-        #
-        # Defines the output directory for the file.
-        #
-        def write_path
-          @write_path ||= ::Brainstem::ApiDocs.write_path
         end
 
         #

--- a/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
+++ b/lib/brainstem/api_docs/sinks/open_api_specification_sink.rb
@@ -15,16 +15,11 @@ module Brainstem
             :api_version,
             :ignore_tagging,
             :format,
-            :write_method,
-            :write_path,
             :oas_filename_pattern,
             :output_extension,
             :include_internal
           ]
         end
-
-        attr_writer :write_method,
-                    :write_path
 
         attr_accessor :api_version,
                       :atlas,

--- a/lib/brainstem/api_docs/sinks/puml_sink.rb
+++ b/lib/brainstem/api_docs/sinks/puml_sink.rb
@@ -5,10 +5,10 @@ module Brainstem
     module Sinks
       class PumlSink < AbstractSink
         def self.call(*args)
-          new(*args).call
+          new(*args)
         end
 
-        def call
+        def <<(atlas)
           buffer = StringIO.new
           buffer.puts("@startuml")
           buffer.puts("@enduml")

--- a/lib/brainstem/api_docs/sinks/puml_sink.rb
+++ b/lib/brainstem/api_docs/sinks/puml_sink.rb
@@ -9,13 +9,70 @@ module Brainstem
         end
 
         def <<(atlas)
+          write_complete_specification!(atlas)
+          write_individual_class_specifications!(atlas)
+        end
+
+        #######################################################################
+        private
+        #######################################################################
+
+        def format_puml_schema(&block)
           buffer = StringIO.new
+
           buffer.puts("@startuml")
-          atlas.presenters.formatted(:puml).each do |presenter|
-            buffer.puts(presenter)
-          end
+          yield(buffer)
           buffer.puts("@enduml")
-          write_buffer_to_file(buffer.string, 'specification.puml')
+
+          buffer.string
+        end
+
+        #
+        # Dump complete specification to a single file.
+        #
+        def write_complete_specification!(atlas)
+          output = format_puml_schema do |buffer|
+            atlas.presenters.each do |presenter|
+              next if presenter.nodoc?
+
+              buffer.puts(presenter.formatted_as(:puml))
+            end
+          end
+
+          write_buffer_to_file(output, "mavenlink_api_v1_specification.puml")
+        end
+
+        #
+        # Dumps each formatted presenter to a file.
+        #
+        def write_individual_class_specifications!(atlas)
+          atlas.presenters.each do |presenter|
+            next if presenter.nodoc?
+
+            output = format_puml_schema do |buffer|
+              format_options = { add_association_class_definitions: true }
+
+              buffer.puts(presenter.formatted_as(:puml, format_options))
+            end
+
+            write_buffer_to_file(output, individual_class_file_path(presenter))
+          end
+        end
+
+        def individual_class_file_path(associated_presenter)
+          File.join("classes", "{{name}}.{{extension}}")
+            .gsub('{{name}}', individual_class_filename(associated_presenter))
+            .gsub('{{extension}}', "puml")
+        end
+
+        def individual_class_filename(associated_presenter)
+          [
+            'mavenlink_api_v1',
+            associated_presenter.target_class
+                .to_s
+                .underscore
+                .gsub('/', '_')
+          ].join('_')
         end
       end
     end

--- a/lib/brainstem/api_docs/sinks/puml_sink.rb
+++ b/lib/brainstem/api_docs/sinks/puml_sink.rb
@@ -11,6 +11,9 @@ module Brainstem
         def <<(atlas)
           buffer = StringIO.new
           buffer.puts("@startuml")
+          atlas.presenters.formatted(:puml).each do |presenter|
+            buffer.puts(presenter)
+          end
           buffer.puts("@enduml")
           write_buffer_to_file(buffer.string, 'specification.puml')
         end

--- a/lib/brainstem/api_docs/sinks/puml_sink.rb
+++ b/lib/brainstem/api_docs/sinks/puml_sink.rb
@@ -1,0 +1,20 @@
+require 'brainstem/api_docs/sinks/abstract_sink'
+
+module Brainstem
+  module ApiDocs
+    module Sinks
+      class PumlSink < AbstractSink
+        def self.call(*args)
+          new(*args).call
+        end
+
+        def call
+          buffer = StringIO.new
+          buffer.puts("@startuml")
+          buffer.puts("@enduml")
+          write_buffer_to_file(buffer.string, 'specification.puml')
+        end
+      end
+    end
+  end
+end

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -145,6 +145,10 @@ module Brainstem
             options[:sink][:options][:format] = :markdown
           end
 
+          opts.on('--puml', 'use puml format') do
+            options[:sink][:options][:format] = :puml
+          end
+
           opts.on('-m', '--multifile-presenters-and-controllers',
             'dumps presenters and controllers to separate files (default)') do |o|
             if options[:sink][:options][:format] == :oas_v2

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -154,7 +154,7 @@ module Brainstem
             'dumps presenters and controllers to separate files (default)') do |o|
             if options[:sink][:options][:format] == :oas_v2
               raise NotImplementedError.new("Multi File support for Open API Specification is not supported yet")
-            else
+            elsif options[:sink][:options][:format] != :puml
               options[:sink][:method] = Brainstem::ApiDocs::Sinks::ControllerPresenterMultifileSink.method(:new)
             end
           end

--- a/lib/brainstem/cli/generate_api_docs_command.rb
+++ b/lib/brainstem/cli/generate_api_docs_command.rb
@@ -147,6 +147,7 @@ module Brainstem
 
           opts.on('--puml', 'use puml format') do
             options[:sink][:options][:format] = :puml
+            options[:sink][:method] = Brainstem::ApiDocs::Sinks::PumlSink
           end
 
           opts.on('-m', '--multifile-presenters-and-controllers',

--- a/spec/brainstem/api_docs/formatters/markdown/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/markdown/presenter_formatter_spec.rb
@@ -384,7 +384,6 @@ module Brainstem
 
               before do
                 stub(presenter).valid_filters { valid_filters }
-                subject.send(:format_filters!)
               end
 
               context "when has filters" do
@@ -399,10 +398,14 @@ module Brainstem
                 }
 
                 it "outputs a header" do
+                  subject.send(:format_filters!)
+
                   expect(subject.output).to include "Filters"
                 end
 
                 it "lists them" do
+                  subject.send(:format_filters!)
+
                   expect(subject.output.scan(/\n-/).count).to eq 1
                   expect(subject.output).to include "`published` (`String`)"
                   expect(subject.output).to include "    - limits to published"
@@ -421,15 +424,36 @@ module Brainstem
                   }
 
                   it "lists them with items" do
+                    subject.send(:format_filters!)
+
                     expect(subject.output.scan(/\n-/).count).to eq 1
                     expect(subject.output).to include "`published` (`String`)"
                     expect(subject.output).to include "    - limits to published. Available values: fizz, buzz."
+                  end
+
+                  context "when items are not an array" do
+                    let(:valid_filters) {
+                      {
+                          "published" => {
+                              type:  "string",
+                              value: Proc.new { nil },
+                              info:  "limits to published",
+                              items: "fizz buzz"
+                          }
+                      }
+                    }
+
+                    it 'raises an error' do
+                      expect { subject.send(:format_filters!) }.to raise_error(RuntimeError)
+                    end
                   end
                 end
               end
 
               context "when no filters" do
                 it "says nothing" do
+                  subject.send(:format_filters!)
+
                   expect(subject.output).to_not include "Filters"
                 end
               end

--- a/spec/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/param_definitions_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/open_api_specification/version_2/endpoint/param_definitions_formatter_spec.rb
@@ -707,6 +707,22 @@ module Brainstem
                       }
                     ])
                   end
+
+                  context "when items option specified on a filter is not an array" do
+                    let(:mocked_valid_filters) {
+                      {
+                        filter_1: { type: 'array', item_type: 'string', items: 'Option 1 Option 2', default: 'Option 1' }
+                      }
+                    }
+
+                    before do
+                      mock(presenter).target_class { Workspace }
+                    end
+
+                    it 'raises an error' do
+                      expect { subject.send(:format_filter_params!) }.to raise_error(RuntimeError)
+                    end
+                  end
                 end
               end
             end

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -98,6 +98,7 @@ module Brainstem
                   presenter_class.associations do
                     association :food, :polymorphic, type: :has_one, polymorphic_classes: [Cheese]
                     association :entities, :polymorphic, type: :has_many, polymorphic_classes: [Post, Task]
+                    association :objects, :polymorphic, type: :has_many
                   end
                 end
 

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+require 'brainstem/api_docs.rb'
+require 'brainstem/api_docs/formatters/puml/presenter_formatter'
+require 'brainstem/api_docs/presenter'
+
+module Brainstem
+  module ApiDocs
+    module Formatters
+      module Puml
+        describe PresenterFormatter do
+          let(:presenter_class) do
+            Class.new(Brainstem::Presenter) do
+              presents Workspace
+              title "Project (Workspace)"
+            end
+          end
+
+          let(:presenter) { Presenter.new(Object.new, const: presenter_class, target_class: 'Workspace') }
+
+          subject { Brainstem::ApiDocs::FORMATTERS[:presenter][:puml].call(presenter) }
+
+          describe "#call" do
+            it "outputs the title as the class name" do
+              expect(subject).to match(/class Workspace {\n.*}/)
+            end
+
+            describe "formatting fields" do
+              xcontext "when no fields explicitly defined" do
+                it "adds id field by default" do
+                  presenter_class.fields do
+                  end
+
+                  expect(subject).to include("integer id")
+                end
+              end
+
+              context "when fields are defined" do
+                before do
+                  presenter_class.fields do
+                    field :name, :string
+                    field :creator_id, :integer
+                    field :archived, :boolean
+                  end
+                end
+
+                it "adds the string field to the output" do
+                  expect(subject).to include("string name\ninteger creator_id\nboolean archived\n")
+                end
+              end
+            end
+
+            context "when nodoc" do
+              let(:presenter) { OpenStruct.new(nodoc?: true) }
+
+              it "returns an empty string" do
+                expect(subject).to eq("")
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -46,7 +46,13 @@ module Brainstem
                 end
 
                 it "adds the string field to the output" do
-                  expect(subject).to include("string name\ninteger creator_id\nboolean archived\n")
+                  expect(subject).to eq(<<~PUML)
+                    class User {
+                    string name
+                    integer creator_id
+                    boolean archived
+                    }
+                  PUML
                 end
               end
 

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -26,7 +26,17 @@ module Brainstem
               expect(subject).to match(/class Workspace {\n.*}/)
             end
 
+            context "when nodoc" do
+              let(:presenter) { OpenStruct.new(nodoc?: true) }
+
+              it "returns an empty string" do
+                expect(subject).to eq("")
+              end
+            end
+
             describe "formatting fields" do
+              let(:target_class) { 'User' }
+
               xcontext "when no fields explicitly defined" do
                 it "adds id field by default" do
                   presenter_class.fields do
@@ -55,36 +65,41 @@ module Brainstem
                   PUML
                 end
               end
-
-              context "when associations are defined" do
-                let(:target_class) { 'User' }
-
-                before do
-                  presenter_class.fields do
-                    field :name, :string
-                  end
-
-                  presenter_class.associations do
-                    association :cheese, Cheese, type: :has_one
-                  end
-                end
-
-                it "can add a has_one association to the output" do
-                  expect(subject).to eq(<<~PUML)
-                    class User {
-                    string name
-                    }
-                    User o-- "1" Cheese
-                  PUML
-                end
-              end
             end
 
-            context "when nodoc" do
-              let(:presenter) { OpenStruct.new(nodoc?: true) }
+            describe "when associations are defined" do
+              let(:target_class) { 'User' }
 
-              it "returns an empty string" do
-                expect(subject).to eq("")
+              before do
+                presenter_class.fields do
+                  field :name, :string
+                end
+              end
+
+              it "adds a has_one association to the output" do
+                presenter_class.associations do
+                  association :cheese, Cheese, type: :has_one
+                end
+
+                expect(subject).to eq(<<~PUML)
+                  class User {
+                  string name
+                  }
+                  User o-- "1" Cheese
+                PUML
+              end
+
+              it "adds a has_many association to the output" do
+                presenter_class.associations do
+                  association :posts, Post, type: :has_many
+                end
+
+                expect(subject).to eq(<<~PUML)
+                  class User {
+                  string name
+                  }
+                  User *-- "n" Post
+                PUML
               end
             end
           end

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -37,33 +37,22 @@ module Brainstem
             describe "formatting fields" do
               let(:target_class) { 'User' }
 
-              xcontext "when no fields explicitly defined" do
-                it "adds id field by default" do
-                  presenter_class.fields do
-                  end
-
-                  expect(subject).to include("integer id")
+              before do
+                presenter_class.fields do
+                  field :name, :string
+                  field :creator_id, :integer
+                  field :archived, :boolean
                 end
               end
 
-              context "when fields are defined" do
-                before do
-                  presenter_class.fields do
-                    field :name, :string
-                    field :creator_id, :integer
-                    field :archived, :boolean
-                  end
-                end
-
-                it "adds the string field to the output" do
-                  expect(subject).to eq(<<~PUML)
-                    class User {
-                    string name
-                    integer creator_id
-                    boolean archived
-                    }
-                  PUML
-                end
+              it "adds the string field to the output" do
+                expect(subject).to eq(<<~PUML)
+                  class User {
+                  string name
+                  integer creator_id
+                  boolean archived
+                  }
+                PUML
               end
             end
 

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -22,7 +22,7 @@ module Brainstem
           subject { Brainstem::ApiDocs::FORMATTERS[:presenter][:puml].call(presenter) }
 
           describe "#call" do
-            it "outputs the title as the class name" do
+            it "outputs the target class as the class name" do
               expect(subject).to match(/class Workspace {\n.*}/)
             end
 
@@ -45,12 +45,12 @@ module Brainstem
                 end
               end
 
-              it "adds the string field to the output" do
+              it "adds attribues to the output alphabetically" do
                 expect(subject).to eq(<<~PUML)
                   class User {
-                  string name
-                  integer creator_id
                   boolean archived
+                  integer creator_id
+                  string name
                   }
                 PUML
               end

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -92,6 +92,26 @@ module Brainstem
                   User *-- "n" Task : task_ids
                 PUML
               end
+
+              context "when associations are polymorphic" do
+                before do
+                  presenter_class.associations do
+                    association :food, :polymorphic, type: :has_one, polymorphic_classes: [Cheese]
+                    association :entities, :polymorphic, type: :has_many, polymorphic_classes: [Post, Task]
+                  end
+                end
+
+                it "adds an association for every polymorphic class to the output" do
+                  expect(subject).to eq(<<~PUML)
+                  class User {
+                  string name
+                  }
+                  User o-- "1" Cheese : food
+                  User *-- "n" Post : entities
+                  User *-- "n" Task : entities
+                  PUML
+                end
+              end
             end
           end
         end

--- a/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/puml/presenter_formatter_spec.rb
@@ -85,20 +85,22 @@ module Brainstem
                   class User {
                   string name
                   }
-                  User o-- "1" Cheese
+                  User o-- "1" Cheese : cheese_id
                 PUML
               end
 
               it "adds a has_many association to the output" do
                 presenter_class.associations do
                   association :posts, Post, type: :has_many
+                  association :tasks, Task, type: :has_many, response_key: :task_ids
                 end
 
                 expect(subject).to eq(<<~PUML)
                   class User {
                   string name
                   }
-                  User *-- "n" Post
+                  User *-- "n" Post : post_ids
+                  User *-- "n" Task : task_ids
                 PUML
               end
             end

--- a/spec/brainstem/api_docs/sinks/puml_sink_spec.rb
+++ b/spec/brainstem/api_docs/sinks/puml_sink_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'brainstem/api_docs/sinks/puml_sink'
+
+module Brainstem
+  module ApiDocs
+    module Sinks
+      describe PumlSink do
+        mock_writer_class = Class.new do
+          def call(buffer, file)
+            @written = buffer
+            @file = file
+          end
+
+          attr_reader :written, :file
+        end
+
+        let(:mock_writer) { mock_writer_class.new }
+        subject { described_class.new(writer: mock_writer) }
+
+        it "writes the header" do
+          subject.call
+          expect(mock_writer.written).to include("@startuml")
+        end
+
+        it "writes the footer" do
+          subject.call
+          expect(mock_writer.written).to include("@enduml")
+        end
+        
+        it "writes out to a puml spec file" do
+          subject.call
+          expect(mock_writer.file).to eq("specification.puml")
+        end
+      end
+    end
+  end
+end 

--- a/spec/brainstem/api_docs/sinks/puml_sink_spec.rb
+++ b/spec/brainstem/api_docs/sinks/puml_sink_spec.rb
@@ -14,8 +14,18 @@ module Brainstem
           attr_reader :written, :file
         end
 
+        mock_presenter_collection = Class.new do
+          def formatted(format)
+            raise 'unexpected format' unless format == :puml
+            ["formatted", "presenters"]
+          end
+
+          attr_reader :format, :method
+        end
+
+        let(:mock_presenters) { mock_presenter_collection.new }
         let(:mock_writer) { mock_writer_class.new }
-        let(:atlas) { Object.new }
+        let(:atlas) { OpenStruct.new(presenters: mock_presenters) }
         subject { described_class.new(writer: mock_writer) }
 
         it "writes the header" do
@@ -31,6 +41,11 @@ module Brainstem
         it "writes out to a puml spec file" do
           subject << atlas
           expect(mock_writer.file).to eq("specification.puml")
+        end
+
+        it "writes out all the presenters in the correct format" do
+          subject << atlas
+          expect(mock_writer.written).to include("formatted\npresenters")
         end
       end
     end

--- a/spec/brainstem/api_docs/sinks/puml_sink_spec.rb
+++ b/spec/brainstem/api_docs/sinks/puml_sink_spec.rb
@@ -15,20 +15,21 @@ module Brainstem
         end
 
         let(:mock_writer) { mock_writer_class.new }
+        let(:atlas) { Object.new }
         subject { described_class.new(writer: mock_writer) }
 
         it "writes the header" do
-          subject.call
+          subject << atlas
           expect(mock_writer.written).to include("@startuml")
         end
 
         it "writes the footer" do
-          subject.call
+          subject << atlas
           expect(mock_writer.written).to include("@enduml")
         end
         
         it "writes out to a puml spec file" do
-          subject.call
+          subject << atlas
           expect(mock_writer.file).to eq("specification.puml")
         end
       end

--- a/spec/brainstem/cli/generate_api_docs_command_spec.rb
+++ b/spec/brainstem/cli/generate_api_docs_command_spec.rb
@@ -28,6 +28,7 @@ module Brainstem
 
           it "sets the sink options to use puml format" do
             expect(subject.options[:sink][:options][:format]).to eq(:puml)
+            expect(subject.options[:sink][:method]).to eq(Brainstem::ApiDocs::Sinks::PumlSink)
           end
         end
 

--- a/spec/brainstem/cli/generate_api_docs_command_spec.rb
+++ b/spec/brainstem/cli/generate_api_docs_command_spec.rb
@@ -23,6 +23,14 @@ module Brainstem
           end
         end
 
+        context "when --puml" do
+          let(:args) { %w(--puml) }
+
+          it "sets the sink options to use puml format" do
+            expect(subject.options[:sink][:options][:format]).to eq(:puml)
+          end
+        end
+
         context "when --multifile-presenters-and-controllers" do
           let(:args) { %w(--multifile-presenters-and-controllers) }
 

--- a/spec/spec_helpers/schema.rb
+++ b/spec/spec_helpers/schema.rb
@@ -51,6 +51,7 @@ end
 
 class User < ActiveRecord::Base
   has_many :workspaces
+  has_one :cheese
 
   def type
     self.class.name


### PR DESCRIPTION
Add the ability to generate a PlantUML specification of our presenters and how they are associated to each other.
![image](https://user-images.githubusercontent.com/11201558/63180418-77e23f00-c00b-11e9-832b-7740e108ff4f.png)

This file can then be used with the PlantUML program to generate a diagram.

---

You can generate these docs by running 
`bundle exec brainstem generate --puml -o .`

You can then take the generated `specification.puml` file and supply it to PlantUML
`java -jar plantuml.jar specification.puml -tsvg`

By default, PlantUML will generate a PNG. I've found that Bigmaven is too large for this to work, so the `-tsvg` option will generate an svg.

You'll need to grab the PlantUML jar file and make sure Graphviz is installed on your machine for it to work. You can get Graphviz with `brew install graphviz` on Mac.

See http://plantuml.com/starting for more.