### PR TITLE
Fix Empty has_many Association Presentation

### DIFF
--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -369,8 +369,8 @@ module Brainstem
           struct["#{singular_external_name}_ref"] = make_model_ref(associated_model_or_models)
         end
       else
-        if associated_model_or_models.is_a?(Array) || associated_model_or_models.is_a?(ActiveRecord::Relation)
-          struct["#{singular_external_name}_ids"] = associated_model_or_models.map { |associated_model| to_s_except_nil(associated_model.try(:id)) }
+        if associated_model_or_models.is_a?(Array) || associated_model_or_models.is_a?(ActiveRecord::Relation) || association.type == :has_many
+          struct["#{singular_external_name}_ids"] = associated_model_or_models&.map { |associated_model| to_s_except_nil(associated_model.try(:id)) } || []
         else
           struct["#{singular_external_name}_id"] = to_s_except_nil(associated_model_or_models.try(:id))
         end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -411,6 +411,20 @@ describe Brainstem::PresenterCollection do
         expect(result['workspaces'].keys).to eq odd_workspace_ids
       end
 
+      context "when a dynamic has many association is empty" do
+        before do
+          @user = User.find(3)
+        end
+
+        it "returns the proper foreign_key name and empty array" do
+          result = @presenter_collection.presenting("users", :params => { :include => "odd_workspaces" }) { User.where(:id => 3) }
+          expect(result['users'][@user.id.to_s]).to be_present
+          expect(result['users'][@user.id.to_s].has_key?('odd_workspace_id')).to be_falsey
+          expect(result['users'][@user.id.to_s]['odd_workspace_ids']).to be_empty
+          expect(result['workspaces'].keys).to be_empty
+        end
+      end
+
       describe "restricted associations" do
         it "does apply includes that are restricted to only queries in an only query" do
           t = Task.first

--- a/spec/spec_helpers/db.rb
+++ b/spec/spec_helpers/db.rb
@@ -1,5 +1,6 @@
 User.create!(:id => 1, :username => "bob")
 User.create!(:id => 2, :username => "jane")
+User.create!(:id => 3, :username => "steve")
 
 Workspace.create!(:id => 1, :user_id => 1, :title => "bob workspace 1", :description => "a")
 Workspace.create!(:id => 2, :user_id => 1, :title => "bob workspace 2", :description => "1")

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -120,7 +120,8 @@ class UserPresenter < Brainstem::Presenter
   associations do
     association :odd_workspaces, Workspace,
                 info: 'only the odd numbered workspaces',
-                dynamic: lambda { |user| user.workspaces.select { |workspace| workspace.id % 2 == 1 } }
+                type: :has_many,
+                dynamic: lambda { |user| user.workspaces.select { |workspace| workspace.id % 2 == 1 }.presence }
   end
 end
 


### PR DESCRIPTION
This fixes a bug that occurs when a dynamic/lookup association in a presenter returns nil. It is always treated as a has_one relationship. Thus the foreign key is incorrect, e.g., `workspace_id` instead of `workspace_ids`. Further the foreign key value is inconsistent with empty `Array`s and `ActiveRecord::Relation`s. So we now ensure that we return
an empty array if the value is nil.