### PR TITLE
Use shared DB connection to execute `SELECT FOUND_ROWS()`

### DIFF
--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -43,7 +43,7 @@ module Brainstem
       def get_ids_sql(scope)
         if Brainstem.mysql_use_calc_found_rows && ActiveRecord::Base.connection.instance_values["config"][:adapter] =~ /mysql/i
           ids = scope.pluck(Arel.sql("SQL_CALC_FOUND_ROWS #{scope.table_name}.id"))
-          @last_count = ActiveRecord::Base.connection.execute("SELECT FOUND_ROWS()").first.first
+          @last_count = scope.connection.execute("SELECT FOUND_ROWS()").first.first
         else
           ids = scope.pluck("#{scope.table_name}.id")
         end


### PR DESCRIPTION
Rely on a shared db connection for evaluated activerecord relation to a…void issues with 'use_transactional_fixtures' config

It seems like brainstem does not work well with 'use_transactional_fixtures' config introduced in Rails 5.1. There are cases where the evaluated active record relation returns an empty array whereas the count returns 1. Our assumption is that `ActiveRecord::Base.connection.execute` generates a separate db connection that works outside the shared db connection introduced in Rails 5.1. We are trying to fix this issue by relying on the db connection associated with the given activerecord relation.