### PR TITLE
Resolve Rails 5.2 deprecation warning for passing raw sql to reorder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    brainstem (2.3.0)
+    brainstem (2.3.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/gemfiles/activerecord4_2.gemfile.lock
+++ b/gemfiles/activerecord4_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    brainstem (2.3.0)
+    brainstem (2.3.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/gemfiles/activerecord5_0.gemfile.lock
+++ b/gemfiles/activerecord5_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    brainstem (2.3.0)
+    brainstem (2.3.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/gemfiles/activerecord5_1.gemfile.lock
+++ b/gemfiles/activerecord5_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    brainstem (2.3.0)
+    brainstem (2.3.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/gemfiles/activerecord5_2.gemfile.lock
+++ b/gemfiles/activerecord5_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    brainstem (2.3.0)
+    brainstem (2.3.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/gemfiles/activerecord6_0.gemfile.lock
+++ b/gemfiles/activerecord6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    brainstem (2.3.0)
+    brainstem (2.3.1)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -214,7 +214,7 @@ module Brainstem
         when nil
           scope
         else
-          scope.reorder(order.to_s + " " + direction)
+          scope.reorder(Arel.sql(order.to_s + " " + direction))
       end
 
       fallback_deterministic_sort = assemble_primary_key_sort(scope)

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "2.3.0"
+  VERSION = "2.3.1"
 end

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -1000,6 +1000,21 @@ describe Brainstem::Presenter do
           # match SQLite and MySQL quotes
           expect(sql).to match(/ORDER BY workspaces\.title asc, [`"]workspaces[`"]\.[`"]id[`"] ASC/i)
         end
+
+        context 'when sorting by associated models' do
+          let(:scope) { Workspace.where(nil).joins(:tasks) }
+          let(:order) { { 'order' => 'tasks:asc' } }
+
+          before do
+            presenter_class.sort_order :tasks, 'COALECE(tasks.name, tasks.created_at)'
+          end
+
+          it 'applies the named ordering in the given direction and adds the primary key as a fallback sort' do
+            sql = presenter.apply_ordering_to_scope(scope, order).to_sql
+            # match SQLite and MySQL quotes
+            expect(sql).to match(/ORDER BY COALECE\(tasks\.name, tasks\.created_at\) asc, [`"]workspaces[`"]\.[`"]id[`"] ASC/i)
+          end
+        end
       end
 
       context 'and is a symbol' do


### PR DESCRIPTION
### Deprecation Warning Fixes
- Wrap interpolated raw SQL with `Arel.sql` to address Rails 5.2 deprecation warning.
  - `DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "COALECE(tasks.name, tasks.created_at) asc". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from apply_ordering_to_scope at ../workspace/brainstem/lib/brainstem/presenter.rb:217)`