### PR TITLE
Add :if option to `valid`

### DIFF
--- a/lib/brainstem/concerns/controller_dsl.rb
+++ b/lib/brainstem/concerns/controller_dsl.rb
@@ -566,8 +566,7 @@ module Brainstem
           .to_h
           .inject(ActiveSupport::HashWithIndifferentAccess.new) do |hsh, (field_name_proc, field_config)|
 
-          if field_config.has_key?(:if)
-            condition = field_config[:if]
+          if (condition = field_config[:if])
             case condition
             when Symbol
               next hsh unless self.send condition

--- a/spec/brainstem/concerns/controller_dsl_spec.rb
+++ b/spec/brainstem/concerns/controller_dsl_spec.rb
@@ -1908,6 +1908,74 @@ module Brainstem
             expect(subject.new.brainstem_valid_params.keys.sort).to eq ["sprocket_parent_id"]
           end
         end
+
+        context "when a valid param has the :if option" do
+          before do
+            any_instance_of(subject) do |instance|
+              stub(instance).action_name { "show" }
+              stub(instance).condition { condition_val }
+            end
+          end
+
+          context "when the condition is a symbol" do
+            before do
+              subject.brainstem_params do
+                actions :show do
+                  model_params(brainstem_model_name) do |params|
+                    params.valid :conditional_param, :string,
+                                 if: :condition
+                  end
+                end
+              end
+            end
+
+            context "when the condition evaluates to truthy" do
+              let(:condition_val) { true }
+
+              it "includes the param in the valid_params" do
+                expect(subject.new.brainstem_valid_params).to have_key("conditional_param")
+              end
+            end
+
+            context "when the condition evaluates to falsey" do
+              let(:condition_val) { false }
+
+
+              it "excludes the param in the valid_params" do
+                expect(subject.new.brainstem_valid_params).to_not have_key("conditional_param")
+              end
+            end
+          end
+
+          context "when the condition is a Proc" do
+            before do
+              subject.brainstem_params do
+                actions :show do
+                  model_params(brainstem_model_name) do |params|
+                    params.valid :conditional_param, :string,
+                                 if: -> { condition }
+                  end
+                end
+              end
+            end
+
+            context "when the condition evaluates to truthy" do
+              let(:condition_val) { true }
+
+              it "evaluates the proc in the context of the subject and includes the param in valid_params" do
+                expect(subject.new.brainstem_valid_params).to have_key("conditional_param")
+              end
+            end
+
+            context "when the condition evaluates to falsey" do
+              let(:condition_val) { false }
+
+              it "evaluates the proc in the context of the subject and excludes the param in valid_params" do
+                expect(subject.new.brainstem_valid_params).to_not have_key("conditional_param")
+              end
+            end
+          end
+        end
       end
 
       describe "#transforms" do


### PR DESCRIPTION
  - When the if option is passed the method or proc is evaluated in the context of the controller instance
    - If the block returns true the param is considered valid and included in the valid_params_tree
    - If the block returns falsey the param is considered invalid and excluded from the valid_params_tree
  - This will allows users to dynamically determine if a brainstem param should be considered valid