### PR TITLE
Allow enums to be reflected in OAS generation

### DIFF
--- a/lib/brainstem/api_docs/formatters/open_api_specification/version_2/field_definitions/response_field_formatter.rb
+++ b/lib/brainstem/api_docs/formatters/open_api_specification/version_2/field_definitions/response_field_formatter.rb
@@ -20,7 +20,7 @@ module Brainstem
               def format
                 field_config = @param_tree[:_config]
                 field_properties = @param_tree.except(:_config)
-  
+
                 format_field(field_config, field_properties)
               end
               alias_method :call, :format
@@ -39,13 +39,13 @@ module Brainstem
 
               def format_nested_array_field(field_config, field_properties)
                 field_properties_data, nested_levels = format_array_items(field_config, field_properties)
-                
+
                 format_nested_array_parent(nested_levels, field_properties_data)
               end
-              
+
               def format_array_items(field_config, field_properties)
                 field_nested_levels = field_config[:nested_levels]
-                
+
                 if field_properties.present?
                   [format_nested_field(field_config, field_properties), field_nested_levels - 1]
                 else
@@ -107,13 +107,14 @@ module Brainstem
                 field_data = type_and_format(field_config[:type], field_config[:item_type])
                 raise(invalid_type_error_message(field_config)) unless field_data
                 field_data.merge!(description: format_sentence(field_config[:info])) if field_config[:info].present?
+                field_data.merge!(enum: field_config[:enum]) if field_config[:enum].present?
                 field_data
               end
 
               def invalid_type_error_message(field_config)
                 <<-MSG.strip_heredoc
                   Unknown Brainstem Field type encountered(#{field_config[:type]}) for field #{field_config[:name]}
-                  in #{@endpoint.controller_name} for #{@endpoint.action} action. 
+                  in #{@endpoint.controller_name} for #{@endpoint.action} action.
                 MSG
               end
 
@@ -130,7 +131,7 @@ module Brainstem
                   end
                 end
               end
-              
+
               def format_description(field_config)
                 format_sentence(field_config[:info])
               end

--- a/spec/brainstem/api_docs/formatters/open_api_specification/version_2/field_definitions/response_field_formatter_spec.rb
+++ b/spec/brainstem/api_docs/formatters/open_api_specification/version_2/field_definitions/response_field_formatter_spec.rb
@@ -261,6 +261,26 @@ module Brainstem
                   end
                 end
 
+                context 'when the field is an enum' do
+                  let(:field_configuration_tree) do
+                    {
+                      _config: {
+                        type: 'string',
+                        info: 'The type of the sprocket.',
+                        enum: %w(Mesh Chain Wheel)
+                      }
+                    }
+                  end
+
+                  it 'is reflected in the oas schema' do
+                    expect(subject).to eq(
+                      'type' => 'string',
+                      'description' => 'The type of the sprocket.',
+                      'enum' => %w(Mesh Chain Wheel)
+                    )
+                  end
+                end
+
                 context 'dynamic keys' do
                   context 'when formatting a hash field' do
                     let(:field_configuration_tree) do


### PR DESCRIPTION
Enums are a legal part of the OAS data format. Brainstem does not allow a way for controllers / parameters to provide these enums though, so this PR is used to expose them.

https://swagger.io/docs/specification/data-models/enums/

By way of example, if the `access_level` in Workspaces:particpations is used as an enum, the only code change necessary is adding the `enum` key with the legal values in an array. The `type` of the field is still respected.

```ruby
participant.valid :access, :string,
                  enum: %w(collaboration time_logging financial admin),
  info: <<~INFO
    The access level of the participant. Must be one of the following: `collaboration`,
    `time_logging`, `financial` or `admin`.
  INFO
```

This generates the api documentation:
![image](https://user-images.githubusercontent.com/3209944/119535261-0ccbad80-bd45-11eb-822e-2b4705b8ea94.png)


And finally the OAS Schema yml file:
```yml
participations:
  type: array
  description: Determines the participants in the project.
  items:
    type: object
    properties:
      user_id:
        type: integer
        format: int32
        description: The user ID of the participant.
      access:
        type: string
        description: |-
          The access level of the participant. Must be one of the following: `collaboration`,
          `time_logging`, `financial` or `admin`.
        enum:
          - collaboration
          - time_logging
          - financial
          - admin
```