### PR TITLE
Allow presenters to override count and id calculation from scope

### DIFF
--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -23,8 +23,8 @@ module Brainstem
       end
 
       module ClassMethods
-        def get_ids_and_count(&block)
-          self.get_ids_sql = block
+        def evaluate_count(&block)
+          self.count_evaluator = block
         end
 
         def preload(*args)

--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -23,6 +23,10 @@ module Brainstem
       end
 
       module ClassMethods
+        def get_ids_and_count(&block)
+          self.get_ids_sql = block
+        end
+
         def preload(*args)
           configuration.array!(:preloads).concat args
         end

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -9,7 +9,7 @@ module Brainstem
   # @abstract Subclass and override {#present} to implement a presenter.
   class Presenter
     include Concerns::PresenterDSL
-    class_attribute :get_ids_sql
+    class_attribute :count_evaluator
 
     # Class methods
 

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -9,6 +9,7 @@ module Brainstem
   # @abstract Subclass and override {#present} to implement a presenter.
   class Presenter
     include Concerns::PresenterDSL
+    class_attribute :get_ids_sql
 
     # Class methods
 

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -62,7 +62,7 @@ module Brainstem
       end
 
       def delegate_to_presenter?
-        primary_presenter.get_ids_sql.present?
+        primary_presenter.get_ids_sql?
       end
 
       def calculate_limit

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "2.3.3"
+  VERSION = "2.3.4"
 end

--- a/spec/brainstem/presenter_collection_spec.rb
+++ b/spec/brainstem/presenter_collection_spec.rb
@@ -158,6 +158,13 @@ describe Brainstem::PresenterCollection do
           result = @presenter_collection.presenting("workspaces", :params => { :per_page => 2, :page => 1 }) { Workspace.unscoped }
           expect(result['count']).to eq(Workspace.count)
         end
+
+        it "allows overrides" do
+          result = @presenter_collection.presenting("line_items") { LineItem.all }
+          line_item_presenter_count = 3
+          expect(LineItem.all.count).not_to eq line_item_presenter_count
+          expect(result['count']).to eq line_item_presenter_count
+        end
       end
 
       describe "meta keys" do

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -99,6 +99,22 @@ describe Brainstem::Presenter do
         end
       end
     end
+
+    describe '.get_ids_sql' do
+      let(:my_class) { Class.new(Brainstem::Presenter) }
+
+      it 'is nil by default' do
+        expect(my_class.get_ids_sql).to eq nil
+      end
+
+      it 'can be set with the dsl' do
+        my_class.get_ids_and_count do
+          'yo dude'
+        end
+
+        expect(my_class.get_ids_sql.call).to eq 'yo dude'
+      end
+    end
   end
 
   describe "#group_present" do
@@ -133,7 +149,7 @@ describe Brainstem::Presenter do
         end
       end
     end
-    
+
     let(:workspace) { Workspace.find_by_title("bob workspace 1") }
     let(:presenter) { presenter_class.new }
 

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -100,19 +100,19 @@ describe Brainstem::Presenter do
       end
     end
 
-    describe '.get_ids_sql' do
+    describe '.evaluate_count' do
       let(:my_class) { Class.new(Brainstem::Presenter) }
 
       it 'is nil by default' do
-        expect(my_class.get_ids_sql).to eq nil
+        expect(my_class.count_evaluator).to eq nil
       end
 
       it 'can be set with the dsl' do
-        my_class.get_ids_and_count do
+        my_class.evaluate_count do
           'yo dude'
         end
 
-        expect(my_class.get_ids_sql.call).to eq 'yo dude'
+        expect(my_class.count_evaluator.call).to eq 'yo dude'
       end
     end
   end

--- a/spec/spec_helpers/db.rb
+++ b/spec/spec_helpers/db.rb
@@ -32,6 +32,12 @@ Post.create!(:id => 1, :user_id => 1, :subject => Workspace.first, :body => "fir
 Post.create!(:id => 2, :user_id => 1, :subject => Task.first, :body => "this is important. get on it!")
 Post.create!(:id => 3, :user_id => 2, :body => "Post without subject")
 
+User.all.each do |user|
+  Workspace.all.each do |workspace|
+    LineItem.create!(user: user, workspace: workspace, amount: 123)
+  end
+end
+
 Attachments::PostAttachment.create!(id: 1, subject: Post.first, filename: 'I am an attachment on a post')
 Attachments::TaskAttachment.create!(id: 2, subject: Task.first, filename: 'I am an attachment on a task')
 

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -137,6 +137,26 @@ class PostPresenter < Brainstem::Presenter
   end
 end
 
+class LineItemPresenter < Brainstem::Presenter
+  presents LineItem
+
+  get_ids_and_count do |scope|
+    ids = [1, 2, 3]
+    count = 3
+
+    [ids, count]
+  end
+
+  fields do
+    field :amount, :integer
+  end
+
+  associations do
+    association :user, User
+    association :workspace, Workspace
+  end
+end
+
 class AttachmentPresenter < Brainstem::Presenter
   presents Attachments::TaskAttachment, Attachments::PostAttachment
 

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -140,11 +140,8 @@ end
 class LineItemPresenter < Brainstem::Presenter
   presents LineItem
 
-  get_ids_and_count do |scope|
-    ids = [1, 2, 3]
-    count = 3
-
-    [ids, count]
+  evaluate_count do |_count_scope|
+    3
   end
 
   fields do

--- a/spec/spec_helpers/schema.rb
+++ b/spec/spec_helpers/schema.rb
@@ -47,6 +47,12 @@ ActiveRecord::Schema.define do
     t.integer :user_id
     t.string :flavor
   end
+
+  create_table :line_items, force: true do |t|
+    t.references :user
+    t.references :workspace
+    t.integer :amount
+  end
 end
 
 class User < ActiveRecord::Base
@@ -117,6 +123,11 @@ class Cheese < ActiveRecord::Base
   belongs_to :user
 
   scope :owned_by, -> id { where(user_id: id) }
+end
+
+class LineItem < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :workspace
 end
 
 module Attachments


### PR DESCRIPTION
In BigMaven we need to cache the count value for `line_items` queries because getting the count is 90% of the compute time for each request. Since the use case is to paginate over all requests within a relatively short amount of time we can get the count and cache it in bigmaven. But we need brainstem to skip calculating the count.