### PR TITLE
instance_exec count_evaluator within context of presenter helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 + **2.3.4** - _08/03/2018_
-+   ### New Features
+  ### New Features
   - Add the ability to delegate count evaluation to presenter which can be useful for caching counts across requests. The block evaluates within the context of any helpers defined for the presenter.
     ```ruby
     class LineItemPresenter < Brainstem::Presenter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
++ **2.3.4** - _08/03/2018_
++   ### New Features
+  - Add the ability to delegate count evaluation to presenter which can be useful for caching counts across requests. The block evaluates within the context of any helpers defined for the presenter.
+    ```ruby
+    class LineItemPresenter < Brainstem::Presenter
+      # presenter...
+      count_evaluator do |count_scope|
+        cached_count? ? cached_count : count_scope.count
+      end
+    end
+    ```
 + **2.3.0** - _10/09/2019_
   ### Version Support
     - Add official Rails 6.0 compatibility

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    brainstem (2.3.3)
+    brainstem (2.3.4)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
 

--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -23,8 +23,8 @@ module Brainstem
       end
 
       module ClassMethods
-        def evaluate_count(&block)
-          self.count_evaluator = block
+        def count_evaluator(&block)
+          configuration[:count_evaluator] = block
         end
 
         def preload(*args)

--- a/lib/brainstem/concerns/presenter_dsl.rb
+++ b/lib/brainstem/concerns/presenter_dsl.rb
@@ -27,6 +27,8 @@ module Brainstem
           configuration[:count_evaluator] = block
         end
 
+        alias evaluate_count :count_evaluator
+
         def preload(*args)
           configuration.array!(:preloads).concat args
         end

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -9,8 +9,6 @@ module Brainstem
   # @abstract Subclass and override {#present} to implement a presenter.
   class Presenter
     include Concerns::PresenterDSL
-    class_attribute :count_evaluator
-
     # Class methods
 
     # Accepts a list of classes that this specific presenter knows how to present. These are not inherited.
@@ -255,6 +253,17 @@ module Brainstem
       end
 
       [sort_name, direction == 'desc' ? 'desc' : 'asc']
+    end
+
+    def evaluate_count(count_scope)
+      return unless evaluate_count?
+
+      evaluator = configuration[:count_evaluator]
+      fresh_helper_instance.instance_exec(count_scope, &evaluator)
+    end
+
+    def evaluate_count?
+      configuration.has_key?(:count_evaluator)
     end
 
     protected

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -27,7 +27,7 @@ module Brainstem
       end
 
       def evaluate_count(count_scope)
-        return primary_presenter.count_evaluator.call(count_scope) if delegate_count_to_presenter?
+        return primary_presenter.evaluate_count(count_scope) if delegate_count_to_presenter?
 
         ret = @last_count || count_scope.count
         @last_count = nil
@@ -64,7 +64,7 @@ module Brainstem
       end
 
       def delegate_count_to_presenter?
-        primary_presenter.count_evaluator?
+        primary_presenter.evaluate_count?
       end
 
       def calculate_limit

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "2.3.4"
+  VERSION = "2.3.5"
 end

--- a/lib/brainstem/version.rb
+++ b/lib/brainstem/version.rb
@@ -1,3 +1,3 @@
 module Brainstem
-  VERSION = "2.3.5"
+  VERSION = "2.3.4"
 end

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -481,6 +481,28 @@ describe Brainstem::Concerns::PresenterDSL do
     end
   end
 
+  describe 'the count_evaluator block' do
+    before do
+      presenter_class.count_evaluator do |_count_scope|
+        3
+      end
+    end
+
+    it 'is stored in the configuration' do
+      expect(presenter_class.configuration[:count_evaluator].call(0)).to eq 3
+    end
+
+    it 'is inherited and overridable' do
+      subclass = Class.new(presenter_class)
+
+      subclass.count_evaluator do |_count_scope|
+        4
+      end
+
+      expect(subclass.configuration[:count_evaluator].call(0)).to eq 4
+    end
+  end
+
   describe ".helper" do
     let(:model) { Workspace.first }
 

--- a/spec/brainstem/concerns/presenter_dsl_spec.rb
+++ b/spec/brainstem/concerns/presenter_dsl_spec.rb
@@ -501,6 +501,12 @@ describe Brainstem::Concerns::PresenterDSL do
 
       expect(subclass.configuration[:count_evaluator].call(0)).to eq 4
     end
+
+    it 'is backward compatible' do
+      expect {
+        presenter_class.evaluate_count { |_| '12' }
+      }.not_to raise_error
+    end
   end
 
   describe ".helper" do

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -100,19 +100,43 @@ describe Brainstem::Presenter do
       end
     end
 
-    describe '.evaluate_count' do
-      let(:my_class) { Class.new(Brainstem::Presenter) }
+    describe '#evaluate_count?' do
+      it 'is true when configuration has an evaluator' do
+        my_class = Class.new(Brainstem::Presenter)
 
-      it 'is nil by default' do
-        expect(my_class.count_evaluator).to eq nil
+        my_class.count_evaluator { |_| 3 }
+        expect(my_class.new.evaluate_count?).to eq true
       end
 
-      it 'can be set with the dsl' do
-        my_class.evaluate_count do
-          'yo dude'
-        end
+      it 'is false when there is no evaluator' do
+        my_class = Class.new(Brainstem::Presenter)
 
-        expect(my_class.count_evaluator.call).to eq 'yo dude'
+        expect(my_class.new.evaluate_count?).to eq false
+      end
+    end
+
+    describe "#evaluate_count" do
+      module CountHelper
+        def count
+          4
+        end
+      end
+
+      it 'evaluates in the context of a helper' do
+        my_class = Class.new(Brainstem::Presenter)
+        my_class.count_evaluator { |_| count }
+        my_class.helper CountHelper
+
+        expect(my_class.new.evaluate_count(0)).to eq 4
+      end
+
+      it 'evaluates without any helper' do
+        my_class = Class.new(Brainstem::Presenter)
+        my_class.count_evaluator { |count_scope| count_scope.count }
+
+        count_scope = OpenStruct.new(count: 42)
+
+        expect(my_class.new.evaluate_count(count_scope)).to eq 42
       end
     end
   end

--- a/spec/spec_helpers/presenters.rb
+++ b/spec/spec_helpers/presenters.rb
@@ -140,7 +140,7 @@ end
 class LineItemPresenter < Brainstem::Presenter
   presents LineItem
 
-  evaluate_count do |_count_scope|
+  count_evaluator do |_count_scope|
     3
   end
 


### PR DESCRIPTION
Count evaluator block needs to be executed with the context of the presenter helper if one is present.