### PR TITLE
Use custom paginator when it is provided

### DIFF
--- a/lib/brainstem/presenter_collection.rb
+++ b/lib/brainstem/presenter_collection.rb
@@ -32,6 +32,7 @@ module Brainstem
     # @option options [Integer] :per_page The number of items that will be returned if <code>params[:per_page]</code> is not set.
     # @option options [Boolean] :apply_default_filters Determine if Presenter's filter defaults should be applied.  On by default.
     # @option options [Brainstem::Presenter] :primary_presenter The Presenter to use for filters and sorts. If unspecified, the +:model+ or +name+ will be used to find an appropriate Presenter.
+    # @option options [paginator] :paginator Optional custom paginator. If unspecified, the default paginator will be used.
     # @yield Must return a scope on the model +name+, which will then be presented.
     # @return [Hash] A hash of arrays of hashes. Top-level hash keys are pluralized model names, with values of arrays containing one hash per object that was found by the given given options.
     def presenting(name, options = {}, &block)

--- a/lib/brainstem/query_strategies/base_strategy.rb
+++ b/lib/brainstem/query_strategies/base_strategy.rb
@@ -41,8 +41,11 @@ module Brainstem
       private
 
       def ids_and_count_for_page(page, scope, count_scope, should_paginate)
-        ids, count = use_calc_row? && @options[:paginator]&.get_paged(page, scope)
-        return [ids, count] if ids && count
+        if use_calc_row? && @options[:paginator]
+          scope = primary_presenter.apply_ordering_to_scope(scope, @options[:params])
+          ids, count = @options[:paginator]&.get_paged(page, scope)
+          return [ids, count] if ids && count
+        end
 
         if should_paginate
           scope, new_count_scope = paginate(scope)

--- a/lib/brainstem/query_strategies/filter_and_search.rb
+++ b/lib/brainstem/query_strategies/filter_and_search.rb
@@ -4,13 +4,10 @@ module Brainstem
       def execute(scope)
         scope, ordered_search_ids = run_search(scope, filter_includes.map(&:name))
         scope = @options[:primary_presenter].apply_filters_to_scope(scope, @options[:params], @options)
-
         if ordering?
           count_scope = scope
-          scope = paginate(scope)
-          scope = @options[:primary_presenter].apply_ordering_to_scope(scope, @options[:params])
-          primary_models = evaluate_scope(scope)
-          count = evaluate_count(count_scope)
+          should_paginate = true
+          primary_models, count = evaluate_scopes(scope, count_scope, should_paginate)
         else
           filtered_ids = scope.pluck(:id)
           count = filtered_ids.size
@@ -60,7 +57,7 @@ module Brainstem
 
       def paginate(scope)
         limit, offset = calculate_limit_and_offset
-        scope.limit(limit).offset(offset).distinct
+        [scope.limit(limit).offset(offset).distinct, nil]
       end
 
       def paginate_array(array)

--- a/lib/brainstem/query_strategies/filter_or_search.rb
+++ b/lib/brainstem/query_strategies/filter_or_search.rb
@@ -18,17 +18,14 @@ module Brainstem
 
           if @options[:params][:only].present?
             # Handle Only
+            should_paginate = false
             scope, count_scope = handle_only(scope, @options[:params][:only])
           else
             # Paginate
-            scope, count_scope = paginate scope
+            should_paginate = true
           end
 
-          # Ordering
-          scope = @options[:primary_presenter].apply_ordering_to_scope(scope, @options[:params])
-
-          primary_models = evaluate_scope(scope)
-          count = evaluate_count(count_scope)
+          primary_models, count = evaluate_scopes(scope, count_scope, should_paginate)
           count = count.keys.length if count.is_a?(Hash)
         end
 


### PR DESCRIPTION
What
---
* Use a provided paginator instead of the strategy's `paginate` method, falling back to original behavior if paginator 
  returns no results.
* Add warning when specs are not run for a given database.
* Unify the return object of paginate methods in strategies.

Why
---
A custom pagination strategy can improve performance on many endpoints, and this allows one to be used.