### PR TITLE
Add setting to skip datetime serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
++ _12/21/2021_
+  ### Performance Optimization
+  - Stop pre-serializing Date and DateTime during presenting.
+
 + **2.3.4** - _08/03/2018_
   ### New Features
   - Add the ability to delegate count evaluation to presenter which can be useful for caching counts across requests. The block evaluates within the context of any helpers defined for the presenter.

--- a/lib/brainstem.rb
+++ b/lib/brainstem.rb
@@ -34,6 +34,19 @@ module Brainstem
     @mysql_use_calc_found_rows || false
   end
 
+  # Sets {skip_datetime_serialize} to a new value.
+  # @param [Boolean] bool
+  # @return [Boolean] the new mysql_use_calc_found_rows setting
+  def self.skip_datetime_serialize=(bool)
+    @skip_datetime_serialize = bool
+  end
+
+  # Whether or not to pre-serialize dates into iso8601
+  # @return [Boolean] the skip_datetime_serialize setting
+  def self.skip_datetime_serialize
+    @skip_datetime_serialize || false
+  end
+
   # @param [String] namespace
   # @return [PresenterCollection] the {PresenterCollection} for the given namespace.
   def self.presenter_collection(namespace = nil)

--- a/lib/brainstem/presenter.rb
+++ b/lib/brainstem/presenter.rb
@@ -115,7 +115,11 @@ module Brainstem
         result = present_fields(model, context, context[:fields])
         load_associations!(model, result, context, options)
         add_id!(model, result)
-        datetimes_to_json(result)
+        if Brainstem.skip_datetime_serialize
+          result
+        else
+          datetimes_to_json(result)
+        end
       end
     end
 

--- a/spec/brainstem/presenter_spec.rb
+++ b/spec/brainstem/presenter_spec.rb
@@ -613,6 +613,38 @@ describe Brainstem::Presenter do
         expect(struct['recursion']['something'].last).to eq(:else)
         expect(struct['recursion']['foo']).to eq(:bar)
       end
+
+      describe "when skip_datetime_serialize is set" do
+        before(:all) do
+          Brainstem.skip_datetime_serialize = true
+        end
+
+        after(:all) do
+          Brainstem.skip_datetime_serialize = false
+        end
+
+        it "should not convert when setting is disabled" do
+          presenter = Class.new(Brainstem::Presenter) do
+            fields do
+              field :time, :datetime, dynamic: lambda { Time.now }
+              field :date, :date, dynamic: lambda { Date.new }
+              fields :recursion do
+                field :time, :datetime, dynamic: lambda { Time.now }
+                field :something, :datetime, dynamic: lambda { [Time.now, :else] }
+                field :foo, :string, dynamic: lambda { :bar }
+              end
+            end
+          end
+
+          struct = presenter.new.group_present([Workspace.first]).first
+          expect(struct['time']).to be_a(Time)
+          expect(struct['date']).to be_a(Date)
+          expect(struct['recursion']['time']).to be_a(Time)
+          expect(struct['recursion']['something'].first).to be_a(Time)
+          expect(struct['recursion']['something'].last).to eq(:else)
+          expect(struct['recursion']['foo']).to eq(:bar)
+        end
+      end
     end
 
     describe "outputting associations" do


### PR DESCRIPTION
This happens automatically in rails, probably thanks to
ActiveSupport defining Time.to_json and Date.to_json or
similar. It's a surprisingly large source of CPU burn to do
it here in a pass that rewrites everything.
